### PR TITLE
[TITS-5216] Added IS_PREVIEW env variable

### DIFF
--- a/src/data-fetching/types.ts
+++ b/src/data-fetching/types.ts
@@ -5,6 +5,7 @@ export interface AlgoliaSettings {
 }
 
 export interface PrezlyNewsroomEnv {
+    IS_PREVIEW: string;
     PREZLY_ACCESS_TOKEN: string;
     PREZLY_NEWSROOM_UUID: string;
     PREZLY_THEME_UUID?: string;


### PR DESCRIPTION
Added `IS_PREVIEW` environment variable to provide themes with information on whether tracking should be enabled/disabled and or any other behaviour changes based on this.