### PR TITLE
Add PREZLY_MODE env variable

### DIFF
--- a/src/data-fetching/index.ts
+++ b/src/data-fetching/index.ts
@@ -6,4 +6,5 @@ export * from './getNewsroomLogoUrl';
 export * from './getPrivacyPortalUrl';
 export * from './getStoryPublicationDate';
 export * from './getUploadcareGroupUrl';
+export * from './lib';
 export * from './types';

--- a/src/data-fetching/lib/index.ts
+++ b/src/data-fetching/lib/index.ts
@@ -1,0 +1,1 @@
+export { getEnvVariables } from './getEnvVariables';

--- a/src/data-fetching/types.ts
+++ b/src/data-fetching/types.ts
@@ -8,6 +8,7 @@ export interface PrezlyNewsroomEnv {
     PREZLY_ACCESS_TOKEN: string;
     PREZLY_NEWSROOM_UUID: string;
     PREZLY_THEME_UUID?: string;
+    PREZLY_MODE?: 'preview';
 }
 
 export interface PrezlyEnv extends PrezlyNewsroomEnv, AlgoliaSettings {}


### PR DESCRIPTION
Providing this variable as `PREZLY_MODE="preview"` will disable tracking on all pages.
Please see https://github.com/prezly/theme-nextjs-bea/pull/94 to learn how it's used.