### PR TITLE
[TITS-5301] Fix next adapter not working for single-language apps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "1.6.2",
+  "version": "1.6.3-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prezly/theme-kit-nextjs",
-      "version": "1.6.2",
+      "version": "1.6.3-0",
       "license": "MIT",
       "dependencies": {
         "@prezly/sdk": "^6.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "1.6.2",
+  "version": "1.6.3-0",
   "description": "Data layer and utility library for developing Prezly themes with NextJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/adapter-nextjs/processRequest.ts
+++ b/src/adapter-nextjs/processRequest.ts
@@ -22,7 +22,9 @@ export function processRequest<Props>(
 
     const { localeResolved, ...pageProps } = props;
 
-    if (!localeResolved) {
+    // If no locale was provided by Next, it most likely means that the theme is not supporting multi-language.
+    // In that case we won't show 404 page.
+    if (!localeResolved && nextLocale) {
         return { notFound: true };
     }
 

--- a/src/intl/locale.ts
+++ b/src/intl/locale.ts
@@ -97,13 +97,14 @@ export function getRedirectToCanonicalLocale(
     redirectPath: string,
     query?: ParsedUrlQuery,
 ): Redirect | undefined {
+    // No need to redirect if no particular locale was requested by the application
+    if (!nextLocaleIsoCode || nextLocaleIsoCode === DUMMY_DEFAULT_LOCALE) {
+        return undefined;
+    }
+
     const shortestLocaleSlug = shortestLocaleCode
         ? LocaleObject.fromAnyCode(shortestLocaleCode).toUrlSlug()
         : shortestLocaleCode;
-
-    if (nextLocaleIsoCode === DUMMY_DEFAULT_LOCALE) {
-        return undefined;
-    }
 
     if (shortestLocaleSlug !== nextLocaleIsoCode) {
         const prefixedPath =


### PR DESCRIPTION
These changes allow for themes that don't support multi-language to still work with theme-kit.
Previously, if `i18n` section of `next.config.js` was not setup for multi-language support, theme would endlessly redirect to the same locale.

Tested on the Heartbeat theme, where this issue was first discovered.
Also tested on Bea to confirm that regular multi-language behavior is still working as intended