### PR TITLE
Add return type override to `getEnvVariables`

### DIFF
--- a/src/data-fetching/lib/getEnvVariables.ts
+++ b/src/data-fetching/lib/getEnvVariables.ts
@@ -29,19 +29,18 @@ function decodeHttpEnv(header: string): Record<string, any> {
 
 export function getEnvVariables<EnvType extends PrezlyEnv = PrezlyEnv>(
     req?: IncomingMessage,
-): EnvType {
+): NodeJS.ProcessEnv & EnvType {
     if (typeof window !== 'undefined') {
         throw new Error('"getEnvVariables" should only be used on back-end side.');
     }
 
     const headerName = (process.env.HTTP_ENV_HEADER || '').toLowerCase();
-    const processEnv = process.env as unknown as EnvType;
 
     if (headerName && req) {
         const header = req.headers[headerName] as string | undefined;
         const httpEnv = decodeHttpEnv(header || '');
-        return { ...processEnv, ...httpEnv };
+        return { ...process.env, ...httpEnv } as NodeJS.ProcessEnv & EnvType;
     }
 
-    return { ...processEnv };
+    return { ...process.env } as NodeJS.ProcessEnv & EnvType;
 }

--- a/src/data-fetching/lib/getEnvVariables.ts
+++ b/src/data-fetching/lib/getEnvVariables.ts
@@ -27,18 +27,21 @@ function decodeHttpEnv(header: string): Record<string, any> {
     return decodeJson(header);
 }
 
-export function getEnvVariables(req?: IncomingMessage): PrezlyEnv {
+export function getEnvVariables<EnvType extends PrezlyEnv = PrezlyEnv>(
+    req?: IncomingMessage,
+): EnvType {
     if (typeof window !== 'undefined') {
         throw new Error('"getEnvVariables" should only be used on back-end side.');
     }
 
     const headerName = (process.env.HTTP_ENV_HEADER || '').toLowerCase();
+    const processEnv = process.env as unknown as EnvType;
 
     if (headerName && req) {
         const header = req.headers[headerName] as string | undefined;
         const httpEnv = decodeHttpEnv(header || '');
-        return { ...process.env, ...httpEnv };
+        return { ...processEnv, ...httpEnv };
     }
 
-    return { ...process.env };
+    return { ...processEnv };
 }


### PR DESCRIPTION
This feature was done mainly because of [this code in the Heartbeat Theme](https://github.com/prezly/theme-nextjs-heartbeat/blob/7a47166c4fa880849e45d080f41042d6f4869e95/pages/%5Bslug%5D.tsx#L41-L46).

The thing is that it'd be nice to use the same `getEnvVariables` method provided by theme-kit to also get any custom env variables specific to the theme (which it does either way, but TS is complaining about type mismatch).

Now I'm not sure whether the type cast added here is better than just doing this in the Heartbeat code:
```ts
const env = getEnvVariables(context.req) as ProcessEnv;
```