### PR TITLE
[HD-361] Sort categories by order property

### DIFF
--- a/src/data-fetching/api/PrezlyApi.ts
+++ b/src/data-fetching/api/PrezlyApi.ts
@@ -181,7 +181,9 @@ export class PrezlyApi {
     }
 
     async getCategories(): Promise<Category[]> {
-        const categories = await this.sdk.newsroomCategories.list(this.newsroomUuid);
+        const categories = await this.sdk.newsroomCategories.list(this.newsroomUuid, {
+            sortOrder: '+order',
+        });
 
         return Array.isArray(categories) ? categories : Object.values(categories);
     }

--- a/src/data-fetching/api/PrezlyApi.ts
+++ b/src/data-fetching/api/PrezlyApi.ts
@@ -27,6 +27,7 @@ import {
     getStoriesQuery,
 } from './queries';
 
+const CATEGORIES_SORT_ORDER = '+order';
 const DEFAULT_SORT_ORDER: SortOrder = 'desc';
 
 type SortOrder = 'desc' | 'asc';
@@ -182,7 +183,7 @@ export class PrezlyApi {
 
     async getCategories(): Promise<Category[]> {
         const categories = await this.sdk.newsroomCategories.list(this.newsroomUuid, {
-            sortOrder: '+order',
+            sortOrder: CATEGORIES_SORT_ORDER,
         });
 
         return Array.isArray(categories) ? categories : Object.values(categories);


### PR DESCRIPTION
I haven't tested it but we use it the exact same way in the [main app](https://github.com/prezly/prezly/pull/11044/files#diff-e61f0a6d9d5c9bad7543c00071937d7349efca379ef603a14e5c45f25458ddabR40) where it works correctly 🙂 