### PR TITLE
[TF-996] Fix issues with `es-419` locale

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "1.14.0",
+  "version": "1.14.1-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prezly/theme-kit-nextjs",
-      "version": "1.14.0",
+      "version": "1.14.1-0",
       "license": "MIT",
       "dependencies": {
         "@prezly/sdk": "^6.24.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "1.14.0",
+  "version": "1.14.1-0",
   "description": "Data layer and utility library for developing Prezly themes with NextJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/__mocks__/languages.ts
+++ b/src/__mocks__/languages.ts
@@ -362,4 +362,47 @@ export const LANGUAGES: Record<string, NewsroomLanguageSettings> = {
                 '<p>Al confirmar su suscripción, confirma que entiende que se está registrando para recibir contenido y accede a que su información se procese y guarde de manera segura.</p>',
         },
     },
+    es_419: {
+        code: 'es_419',
+        locale: {
+            code: 'es_419',
+            locale: 'es_419',
+            name: 'Spanish (Latin America)',
+            native_name: 'Español (Latinoamérica)',
+            direction: TextDirection.LTR,
+            language_code: 'es',
+        },
+        is_default: false,
+        stories_count: 0,
+        public_stories_count: 0,
+        categories_count: 0,
+        default_email_disclaimer:
+            "<p>Ha recibido este correo electrónico porque usted es uno de los contactos de %companyname%. Si no quiere seguir recibiendo estos correos electrónicos, por favor, <a href='%unsubscribe_url%'>cancele la suscripción</a>.</p>",
+        default_cookie_statement:
+            '<p>Utilizamos cookies en nuestro sitio web. Nos ayudan a conocerle un poco y saber cómo usa nuestro sitio web, lo que nos sirve para proporcionarle a usted y a los demás una experiencia más valiosa y personalizada.</p>',
+        default_subscribe_disclaimer:
+            '<p>Al confirmar su suscripción, confirma que entiende que se está registrando para recibir contenido y accede a que su información se procese y guarde de manera segura.</p>',
+        company_information: {
+            name: 'The Good News Room',
+            about: '',
+            about_plaintext: '',
+            email: null,
+            website: null,
+            phone: null,
+            address: null,
+            twitter: null,
+            facebook: null,
+            linkedin: null,
+            pinterest: null,
+            youtube: null,
+            instagram: null,
+            tiktok: null,
+            email_disclaimer:
+                '<p>Ha recibido este correo electrónico porque usted es uno de los contactos de %companyname%. Si no quiere seguir recibiendo estos correos electrónicos, por favor, <a href="%unsubscribe_url%">cancele la suscripción</a>.</p>',
+            cookie_statement:
+                '<p>Utilizamos cookies en nuestro sitio web. Nos ayudan a conocerle un poco y saber cómo usa nuestro sitio web, lo que nos sirve para proporcionarle a usted y a los demás una experiencia más valiosa y personalizada.</p>',
+            subscribe_disclaimer:
+                '<p>Al confirmar su suscripción, confirma que entiende que se está registrando para recibir contenido y accede a que su información se procese y guarde de manera segura.</p>',
+        },
+    },
 };

--- a/src/intl/languages.test.ts
+++ b/src/intl/languages.test.ts
@@ -200,7 +200,12 @@ describe('getShortestLocaleCode', () => {
     });
 
     it('returns neutral language code if it is the only culture with that language', () => {
-        expect(getShortestLocaleCode(ALL_LANGUAGES, LocaleObject.fromAnyCode('es-ES'))).toBe('es');
+        expect(
+            getShortestLocaleCode(
+                ALL_LANGUAGES.filter(({ code }) => code !== 'es_419'),
+                LocaleObject.fromAnyCode('es-ES'),
+            ),
+        ).toBe('es');
     });
 
     it('returns region code if it is the only culture with that region', () => {
@@ -216,6 +221,12 @@ describe('getShortestLocaleCode', () => {
         );
         expect(getShortestLocaleCode(ALL_LANGUAGES, LocaleObject.fromAnyCode('nl-BE'))).toBe(
             'nl_BE',
+        );
+    });
+
+    it('returns full code when trying to shorten to region code for es-419', () => {
+        expect(getShortestLocaleCode(ALL_LANGUAGES, LocaleObject.fromAnyCode('es-419'))).toBe(
+            'es_419',
         );
     });
 });

--- a/src/intl/languages.ts
+++ b/src/intl/languages.ts
@@ -214,7 +214,7 @@ export function getShortestLocaleCode(
         // If there are 2 or more matching neutral languages, it means that there are no languages that can be shortened to neutral code
         mathchingNeutralLanguagesByRegionCode.length !== 1 &&
         // We don't want just numbers in our region code
-        shortRegionCode !== '419'
+        Number.isNaN(Number(shortRegionCode))
     ) {
         return shortRegionCode;
     }

--- a/src/intl/languages.ts
+++ b/src/intl/languages.ts
@@ -212,7 +212,9 @@ export function getShortestLocaleCode(
     if (
         matchingLanguagesByRegionCode.length === 1 &&
         // If there are 2 or more matching neutral languages, it means that there are no languages that can be shortened to neutral code
-        mathchingNeutralLanguagesByRegionCode.length !== 1
+        mathchingNeutralLanguagesByRegionCode.length !== 1 &&
+        // We don't want just numbers in our region code
+        shortRegionCode !== '419'
     ) {
         return shortRegionCode;
     }

--- a/src/intl/localeConfig.js
+++ b/src/intl/localeConfig.js
@@ -12,7 +12,11 @@ const lowercaseLocalPermutations = Array.from(
     new Set([
         ...lowercaseLocales,
         ...lowercaseLocales.map((code) => code.split('-')[0]),
-        ...lowercaseLocales.map((code) => code.split('-')[1]).filter(Boolean),
+        ...lowercaseLocales
+            .map((code) => code.split('-')[1])
+            .filter(Boolean)
+            // Remove `419` from possible permutations of `es-419`
+            .filter((code) => code !== '419'),
     ]),
 ).sort();
 

--- a/src/intl/localeConfig.js
+++ b/src/intl/localeConfig.js
@@ -15,8 +15,8 @@ const lowercaseLocalPermutations = Array.from(
         ...lowercaseLocales
             .map((code) => code.split('-')[1])
             .filter(Boolean)
-            // Remove `419` from possible permutations of `es-419`
-            .filter((code) => code !== '419'),
+            // Remove number-only codes from possible permutations (like `419` for `es-419`)
+            .filter((code) => Number.isNaN(Number(code))),
     ]),
 ).sort();
 

--- a/src/intl/localeObject.test.ts
+++ b/src/intl/localeObject.test.ts
@@ -24,6 +24,9 @@ it('accepts any valid code type and converts it to hyphen code consistently', ()
     expect(LocaleObject.fromAnyCode('en_us').toHyphenCode()).toBe('en-US');
     expect(LocaleObject.fromAnyCode('en_US').toHyphenCode()).toBe('en-US');
     expect(LocaleObject.fromAnyCode('EN_US').toHyphenCode()).toBe('en-US');
+
+    expect(LocaleObject.fromAnyCode('es-419').toHyphenCode()).toBe('es-419');
+    expect(LocaleObject.fromAnyCode('es_419').toHyphenCode()).toBe('es-419');
 });
 
 it('converts to underscore code consistently', () => {


### PR DESCRIPTION
The issue was that `es-419` code was being shortened to `419` (aka the short region code), but it didn't pass the regexp that I previosly set up for checking that locale code conforms to ISO standarts.

I don't think that URLs like `/419/..` would be a good thing anyway, so I updated the code to exclude the `419` shortcode from possible language codes. 