### PR TITLE
[TF-804] Properly handle API Error 410: Gone for Story Preview

### DIFF
--- a/src/data-fetching/api/PrezlyApi.ts
+++ b/src/data-fetching/api/PrezlyApi.ts
@@ -30,6 +30,9 @@ import {
 const CATEGORIES_SORT_ORDER = '+order';
 const DEFAULT_SORT_ORDER: SortOrder = 'desc';
 
+const ERROR_CODE_NOT_FOUND = 404;
+const ERROR_CODE_GONE = 410;
+
 type SortOrder = 'desc' | 'asc';
 
 interface GetStoriesOptions {
@@ -72,7 +75,10 @@ export class PrezlyApi {
         try {
             return await this.sdk.stories.get(uuid);
         } catch (error) {
-            if (isSdkError(error) && error.status === 404) {
+            if (
+                isSdkError(error) &&
+                (error.status === ERROR_CODE_NOT_FOUND || error.status === ERROR_CODE_GONE)
+            ) {
                 return null;
             }
             throw error;


### PR DESCRIPTION
We should show a 404 page for this error code.