### PR TITLE
[TF-925] Add experimental SSG support

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,61 @@ export const getServerSideProps = getSitemapServerSideProps(additionalPaths);
 
 If you need a more customized approach, you can build your own Sitemap by extending the `SitemapBuilder` class exported from the library, as well as referring to the code in the [Sitemap](./tree/main/src/adapter-nextjs/page-props/sitemap) component directory.
 
+### Experimental: Static Site Generation
+
+For self-hosted applications, we now provide an option to use SSG in your project. However, this comes with some limitations:
+
+- Multi-langugage is not yet supported. Make sure to remove the `i18n` property from your `next.config.js`.
+- Sitemap will still use SSR to set the XML Content-Type headers on the response.
+- Story preview page needs to use SSR to ensure that content is always up to date.
+
+The workflow is pretty much the same as with our default SSR approach. You will need to use the new `getNewsroomStaticProps` and `processStaticRequest` methods. Note that `getNewsroomStaticProps` returns its props in the `staticProps` property. The data is still the same as in the SSR methods, so apart from multi-language, this should be a drop-in replacement for your pages.
+```tsx
+import { getNewsroomStaticProps, processStaticRequest } from '@prezly/theme-kit-nextjs';
+import type { GetStaticProps } from 'next';
+
+/* Your Page component code */
+
+export const getStaticProps: GetServerSideProps<Props> = async (context) => {
+    const { api, staticProps } = await getNewsroomStaticProps(context);
+
+    /* Your logic to get additional props for this page  */
+
+    return processStaticRequest(
+        context,
+        {
+            ...serverSideProps,
+            myProp: 'My Custom Prop',
+        },
+    );
+};
+```
+
+We also have added all of the page helpers (except Story Preview) for SSG prop fetching. Here's an example for the Home page:
+```ts
+import { getHomepageStaticProps } from '@prezly/theme-kit-nextjs';
+
+/* ...your page component */
+
+export const getStaticProps = getHomepageStaticProps({});
+```
+
+
+For dynamic pages, like `/story/[slug]`, we also provide `getStaticPaths` helper functions:
+```tsx
+import { getStoryPageStaticPaths, getStoryPageStaticProps } from '@prezly/theme-kit-nextjs';
+
+/* Your Page component code */
+
+export const getStaticProps = getStoryPageStaticProps({});
+
+export const getStaticPaths = getStoryPageStaticPaths;
+```
+
+These are available for `/category/[slug]`, `/story/[slug]` and `/media/album/[uuid]` pages.
+
+You can find all of the helper methods in the [page-props](./tree/main/src/adapter-nextjs/page-props) directory.
+
 ----
 
 ## What's next

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "1.14.1",
+  "version": "1.15.0-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prezly/theme-kit-nextjs",
-      "version": "1.14.1",
+      "version": "1.15.0-0",
       "license": "MIT",
       "dependencies": {
         "@prezly/sdk": "^6.24.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "1.14.1",
+  "version": "1.15.0-0",
   "description": "Data layer and utility library for developing Prezly themes with NextJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/adapter-nextjs/getNewsroomStaticProps.ts
+++ b/src/adapter-nextjs/getNewsroomStaticProps.ts
@@ -1,0 +1,29 @@
+import type { Story } from '@prezly/sdk';
+import type { GetStaticPropsContext } from 'next';
+
+import { getPrezlyApi } from '../data-fetching';
+
+interface Options {
+    loadHomepageContacts?: boolean;
+    story?: Story;
+}
+
+/**
+ * Use this function in your `getNewsroomStaticProps` page methods to retrieve the data necessary for the NewsroomContextProvider and `processRequest` function.
+ * See README for usage examples.
+ */
+export async function getNewsroomStaticProps(
+    context: GetStaticPropsContext,
+    options: Options = {},
+) {
+    const { locale } = context;
+
+    const api = getPrezlyApi();
+    const staticProps = await api.getNewsroomServerSideProps(undefined, locale, options.story);
+
+    if (options.loadHomepageContacts) {
+        staticProps.newsroomContextProps.contacts = await api.getNewsroomContacts();
+    }
+
+    return { api, staticProps };
+}

--- a/src/adapter-nextjs/index.ts
+++ b/src/adapter-nextjs/index.ts
@@ -1,4 +1,5 @@
 export * from './api-handlers';
 export * from './getNewsroomServerSideProps';
+export * from './getNewsroomStaticProps';
 export * from './page-props';
 export * from './processRequest';

--- a/src/adapter-nextjs/index.ts
+++ b/src/adapter-nextjs/index.ts
@@ -3,3 +3,4 @@ export * from './getNewsroomServerSideProps';
 export * from './getNewsroomStaticProps';
 export * from './page-props';
 export * from './processRequest';
+export * from './processStaticRequest';

--- a/src/adapter-nextjs/page-props/gallery.ts
+++ b/src/adapter-nextjs/page-props/gallery.ts
@@ -1,10 +1,17 @@
 import type { NewsroomGallery } from '@prezly/sdk';
-import type { GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
+import type {
+    GetServerSidePropsContext,
+    GetServerSidePropsResult,
+    GetStaticPropsContext,
+    GetStaticPropsResult,
+} from 'next';
 
 import type { PaginationProps } from '../../infinite-loading/types';
 import { DEFAULT_GALLERY_PAGE_SIZE } from '../../utils';
 import { getNewsroomServerSideProps } from '../getNewsroomServerSideProps';
+import { getNewsroomStaticProps } from '../getNewsroomStaticProps';
 import { processRequest } from '../processRequest';
+import { processStaticRequest } from '../processStaticRequest';
 
 import type { PropsFunction } from './lib/types';
 
@@ -60,5 +67,45 @@ export function getGalleryPageServerSideProps<CustomProps extends Record<string,
             },
             '/media',
         );
+    };
+}
+
+export function getGalleryPageStaticProps<CustomProps extends Record<string, any>>(
+    customProps: CustomProps | PropsFunction<CustomProps>,
+    options?: Options,
+) {
+    const { pageSize = DEFAULT_GALLERY_PAGE_SIZE } = options || {};
+
+    return async function getStaticProps(
+        context: GetStaticPropsContext,
+    ): Promise<GetStaticPropsResult<GalleryPageProps & CustomProps>> {
+        const { api, staticProps } = await getNewsroomStaticProps(context);
+
+        const { galleries, pagination } = await api.getGalleries({ pageSize });
+
+        // If there's only one gallery, redirect to it immediately
+        if (galleries.length === 1) {
+            const { uuid } = galleries[0];
+
+            return {
+                redirect: {
+                    destination: `/media/album/${uuid}`,
+                    permanent: false,
+                },
+            };
+        }
+
+        return processStaticRequest(context, {
+            ...staticProps,
+            galleries,
+            pagination: {
+                itemsTotal: pagination.matched_records_number,
+                currentPage: 1,
+                pageSize,
+            },
+            ...(typeof customProps === 'function'
+                ? await (customProps as PropsFunction<CustomProps>)(context, staticProps)
+                : customProps),
+        });
     };
 }

--- a/src/adapter-nextjs/page-props/index.ts
+++ b/src/adapter-nextjs/page-props/index.ts
@@ -1,8 +1,26 @@
-export { getCategoryPageServerSideProps, type CategoryPageProps } from './category';
-export { getGalleryPageServerSideProps, type GalleryPageProps } from './gallery';
-export { getGalleryAlbumPageServerSideProps, type GalleryAlbumPageProps } from './galleryAlbum';
-export { getHomepageServerSideProps, type HomePageProps } from './home';
-export { getSearchPageServerSideProps } from './search';
+export {
+    getCategoryPageServerSideProps,
+    getCategoryPageStaticPaths,
+    getCategoryPageStaticProps,
+    type CategoryPageProps,
+} from './category';
+export {
+    getGalleryPageServerSideProps,
+    getGalleryPageStaticProps,
+    type GalleryPageProps,
+} from './gallery';
+export {
+    getGalleryAlbumPageServerSideProps,
+    getGalleryAlbumPageStaticPaths,
+    getGalleryAlbumPageStaticProps,
+    type GalleryAlbumPageProps,
+} from './galleryAlbum';
+export { getHomepageServerSideProps, getHomepageStaticProps, type HomePageProps } from './home';
+export { getSearchPageServerSideProps, getSearchPageStaticProps } from './search';
 export * from './sitemap';
-export { getStoryPageServerSideProps } from './story';
+export {
+    getStoryPageServerSideProps,
+    getStoryPageStaticPaths,
+    getStoryPageStaticProps,
+} from './story';
 export { getStoryPreviewPageServerSideProps } from './storyPreview';

--- a/src/adapter-nextjs/page-props/lib/types.ts
+++ b/src/adapter-nextjs/page-props/lib/types.ts
@@ -1,8 +1,8 @@
-import type { GetServerSidePropsContext } from 'next';
+import type { GetServerSidePropsContext, GetStaticPropsContext } from 'next';
 
 import type { PageProps } from '../../../types';
 
 export type PropsFunction<CustomProps> = (
-    context: GetServerSidePropsContext,
+    context: GetServerSidePropsContext | GetStaticPropsContext,
     props: PageProps,
 ) => CustomProps | Promise<CustomProps>;

--- a/src/adapter-nextjs/page-props/search.ts
+++ b/src/adapter-nextjs/page-props/search.ts
@@ -1,7 +1,9 @@
 import type { GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
 
 import { getNewsroomServerSideProps } from '../getNewsroomServerSideProps';
+import { getNewsroomStaticProps } from '../getNewsroomStaticProps';
 import { processRequest } from '../processRequest';
+import { processStaticRequest } from '../processStaticRequest';
 
 import type { PropsFunction } from './lib/types';
 
@@ -23,5 +25,22 @@ export function getSearchPageServerSideProps<CustomProps extends Record<string, 
             },
             '/search',
         );
+    };
+}
+
+export function getSearchPageStaticProps<CustomProps extends Record<string, any>>(
+    customProps: CustomProps | PropsFunction<CustomProps>,
+) {
+    return async function getStaticProps(
+        context: GetServerSidePropsContext,
+    ): Promise<GetServerSidePropsResult<CustomProps>> {
+        const { staticProps } = await getNewsroomStaticProps(context);
+
+        return processStaticRequest(context, {
+            ...staticProps,
+            ...(typeof customProps === 'function'
+                ? await (customProps as PropsFunction<CustomProps>)(context, staticProps)
+                : customProps),
+        });
     };
 }

--- a/src/adapter-nextjs/processRequest.ts
+++ b/src/adapter-nextjs/processRequest.ts
@@ -1,27 +1,23 @@
-import type {
-    GetServerSidePropsContext,
-    GetServerSidePropsResult,
-    GetStaticPropsContext,
-} from 'next';
+import type { GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
 
 import { getRedirectToCanonicalLocale, getShortestLocaleCode, LocaleObject } from '../intl';
 import type { PageProps, ServerSidePageProps } from '../types';
 
 /**
- * This function combines the props returned from `getNewsroomServerSideProps` or `getNewsroomStaticProps` and your optional custom props for the page.
+ * This function combines the props returned from `getNewsroomServerSideProps` and your optional custom props for the page.
  * It also handles locale redirects, if `canonicalUrl` parameter is provided.
  * See README for usage examples.
  *
- * @param context Next.js context passed to the `getServerSideProps` or `getStaticProps` method of the page
+ * @param context Next.js context passed to the `getServerSideProps` method of the page
  * @param props Object containing the return of `getNewsroomServerSideProps` and your optional custom props.
  * @param canonicalUrl Optional: a canonical URL for the current page without locale part. If provided, locale redirects will be handled by the function.
  */
 export function processRequest<Props>(
-    context: GetServerSidePropsContext | GetStaticPropsContext,
+    context: GetServerSidePropsContext,
     props: Props & PageProps & ServerSidePageProps,
     canonicalUrl?: string,
 ): GetServerSidePropsResult<Props> {
-    const { locale: nextLocale } = context;
+    const { locale: nextLocale, query } = context;
 
     const { localeResolved, ...pageProps } = props;
 
@@ -40,7 +36,7 @@ export function processRequest<Props>(
             shortestLocaleCode,
             nextLocale,
             canonicalUrl,
-            'query' in context ? context.query : undefined,
+            query,
         );
         if (redirect) {
             return { redirect };

--- a/src/adapter-nextjs/processRequest.ts
+++ b/src/adapter-nextjs/processRequest.ts
@@ -1,23 +1,27 @@
-import type { GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
+import type {
+    GetServerSidePropsContext,
+    GetServerSidePropsResult,
+    GetStaticPropsContext,
+} from 'next';
 
 import { getRedirectToCanonicalLocale, getShortestLocaleCode, LocaleObject } from '../intl';
 import type { PageProps, ServerSidePageProps } from '../types';
 
 /**
- * This function combines the props returned from `getNewsroomServerSideProps` and your optional custom props for the page.
+ * This function combines the props returned from `getNewsroomServerSideProps` or `getNewsroomStaticProps` and your optional custom props for the page.
  * It also handles locale redirects, if `canonicalUrl` parameter is provided.
  * See README for usage examples.
  *
- * @param context Next.js context passed to the `getServerSideProps` method of the page
+ * @param context Next.js context passed to the `getServerSideProps` or `getStaticProps` method of the page
  * @param props Object containing the return of `getNewsroomServerSideProps` and your optional custom props.
  * @param canonicalUrl Optional: a canonical URL for the current page without locale part. If provided, locale redirects will be handled by the function.
  */
 export function processRequest<Props>(
-    context: GetServerSidePropsContext,
+    context: GetServerSidePropsContext | GetStaticPropsContext,
     props: Props & PageProps & ServerSidePageProps,
     canonicalUrl?: string,
 ): GetServerSidePropsResult<Props> {
-    const { locale: nextLocale, query } = context;
+    const { locale: nextLocale } = context;
 
     const { localeResolved, ...pageProps } = props;
 
@@ -36,7 +40,7 @@ export function processRequest<Props>(
             shortestLocaleCode,
             nextLocale,
             canonicalUrl,
-            query,
+            'query' in context ? context.query : undefined,
         );
         if (redirect) {
             return { redirect };

--- a/src/adapter-nextjs/processStaticRequest.ts
+++ b/src/adapter-nextjs/processStaticRequest.ts
@@ -1,0 +1,32 @@
+import type { GetStaticPropsContext, GetStaticPropsResult } from 'next';
+
+import type { PageProps, ServerSidePageProps } from '../types';
+
+/**
+ * This function combines the props returned from `getNewsroomStaticProps` and your optional custom props for the page.
+ * See README for usage examples.
+ *
+ * @param context Next.js context passed to the `getStaticProps` method of the page
+ * @param props Object containing the return of `getNewsroomServerSideProps` and your optional custom props.
+ * @param revalidateTimeout Optional: timeout in seconds to use with Next ISR.
+ */
+export function processStaticRequest<Props>(
+    context: GetStaticPropsContext,
+    props: Props & PageProps & ServerSidePageProps,
+    revalidateTimeout?: number,
+): GetStaticPropsResult<Props> {
+    const { locale: nextLocale } = context;
+
+    const { localeResolved, ...pageProps } = props;
+
+    // If no locale was provided by Next, it most likely means that the theme is not supporting multi-language.
+    // In that case we won't show 404 page.
+    if (!localeResolved && nextLocale) {
+        return { notFound: true };
+    }
+
+    return {
+        props: pageProps as Props & PageProps,
+        revalidate: revalidateTimeout,
+    };
+}

--- a/src/data-fetching/api/PrezlyApi.ts
+++ b/src/data-fetching/api/PrezlyApi.ts
@@ -45,7 +45,7 @@ interface GetStoriesOptions {
 
 interface GetGalleriesOptions {
     page?: number;
-    pageSize: number;
+    pageSize?: number;
 }
 
 export class PrezlyApi {
@@ -210,7 +210,7 @@ export class PrezlyApi {
     searchStories: typeof PrezlySDK.prototype.stories.search = (options) =>
         this.sdk.stories.search(options);
 
-    async getGalleries({ page = undefined, pageSize }: GetGalleriesOptions) {
+    async getGalleries({ page = undefined, pageSize = 0 }: GetGalleriesOptions) {
         return this.sdk.newsroomGalleries.list(this.newsroomUuid, {
             limit: pageSize,
             offset: typeof page === 'undefined' ? undefined : (page - 1) * pageSize,
@@ -284,5 +284,10 @@ export class PrezlyApi {
             },
             localeResolved: Boolean(currentLanguage),
         };
+    }
+
+    async getNewsroomDefaultLanguage() {
+        const languages = await this.getNewsroomLanguages();
+        return getDefaultLanguage(languages);
     }
 }

--- a/src/data-fetching/api/PrezlyApi.ts
+++ b/src/data-fetching/api/PrezlyApi.ts
@@ -210,10 +210,13 @@ export class PrezlyApi {
     searchStories: typeof PrezlySDK.prototype.stories.search = (options) =>
         this.sdk.stories.search(options);
 
-    async getGalleries({ page = undefined, pageSize = 0 }: GetGalleriesOptions) {
+    async getGalleries({ page, pageSize }: GetGalleriesOptions) {
         return this.sdk.newsroomGalleries.list(this.newsroomUuid, {
             limit: pageSize,
-            offset: typeof page === 'undefined' ? undefined : (page - 1) * pageSize,
+            offset:
+                typeof page === 'undefined' || typeof pageSize === 'undefined'
+                    ? undefined
+                    : (page - 1) * pageSize,
             scope: getGalleriesQuery(),
         });
     }

--- a/src/data-fetching/api/PrezlyApi.ts
+++ b/src/data-fetching/api/PrezlyApi.ts
@@ -248,7 +248,7 @@ export class PrezlyApi {
     }
 
     async getNewsroomServerSideProps(
-        request: IncomingMessage | undefined,
+        request?: IncomingMessage,
         nextLocaleIsoCode?: string,
         story?: Story,
     ): Promise<PageProps & ServerSidePageProps> {


### PR DESCRIPTION
The support is currently limited to single-language newsrooms, since multi-language support is quite tricky to implement and will not fit into the current cycle. This functionality should be enough for our current use-case (the Lifelog theme).

The SSG page props helpers share a lot of code with their SSR counter-parts, but I'm not sure that refactoring should be done in the scope of this PR.