### PR TITLE
[TF-1030] Add shared document class

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "1.15.1",
+  "version": "1.16.0-2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prezly/theme-kit-nextjs",
-      "version": "1.15.1",
+      "version": "1.16.0-2",
       "license": "MIT",
       "dependencies": {
         "@prezly/sdk": "^6.24.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "1.15.1",
+  "version": "1.16.0-2",
   "description": "Data layer and utility library for developing Prezly themes with NextJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/components-nextjs/document.tsx
+++ b/src/components-nextjs/document.tsx
@@ -1,0 +1,30 @@
+import Document, { Head, Html, Main, NextScript } from 'next/document';
+
+import { DEFAULT_LOCALE, getLocaleDirection, LocaleObject } from '../intl';
+import type { PageProps } from '../types';
+
+export class PrezlyThemeDocument extends Document {
+    render() {
+        const {
+            newsroomContextProps: { localeCode = DEFAULT_LOCALE },
+            // eslint-disable-next-line no-underscore-dangle
+        } = this.props.__NEXT_DATA__.props.pageProps as PageProps;
+
+        const locale = LocaleObject.fromAnyCode(localeCode);
+        // TODO: The direction can be pulled from the Language object
+        const direction = getLocaleDirection(locale);
+
+        return (
+            <Html lang={locale.toHyphenCode()} dir={direction}>
+                <Head>
+                    <meta name="og:locale" content={locale.toHyphenCode()} />
+                    {/* TODO: Add alternate locales */}
+                </Head>
+                <body>
+                    <Main />
+                    <NextScript />
+                </body>
+            </Html>
+        );
+    }
+}

--- a/src/components-nextjs/document.tsx
+++ b/src/components-nextjs/document.tsx
@@ -4,13 +4,21 @@ import { DEFAULT_LOCALE, getLocaleDirection, LocaleObject } from '../intl';
 import type { PageProps } from '../types';
 
 export class PrezlyThemeDocument extends Document {
-    render() {
+    getLocaleCode() {
         const {
-            newsroomContextProps: { localeCode = DEFAULT_LOCALE },
+            newsroomContextProps,
             // eslint-disable-next-line no-underscore-dangle
         } = this.props.__NEXT_DATA__.props.pageProps as PageProps;
 
-        const locale = LocaleObject.fromAnyCode(localeCode);
+        // In some cases (like server errors) the newsroom context props will not be loaded.
+        // We need to fall back to default locale to keep the app working.
+        const { localeCode } = newsroomContextProps ?? { localeCode: DEFAULT_LOCALE };
+
+        return localeCode;
+    }
+
+    render() {
+        const locale = LocaleObject.fromAnyCode(this.getLocaleCode());
         // TODO: The direction can be pulled from the Language object
         const direction = getLocaleDirection(locale);
 

--- a/src/components-nextjs/index.ts
+++ b/src/components-nextjs/index.ts
@@ -1,2 +1,3 @@
 export { PageSeo } from './PageSeo';
 export { StorySeo } from './StorySeo';
+export { PrezlyThemeDocument } from './document';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "downlevelIteration": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["dom", "dom.iterable", "es2019"],
+    "lib": ["dom", "es2019"],
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": true,
@@ -16,7 +16,7 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es5",
+    "target": "esnext",
     "jsx": "react-jsx",
     "outDir": "./build",
     "typeRoots": ["./node_modules/@types", "src/@types"]


### PR DESCRIPTION
This is another optimisation to streamline the common `_document` wrapper for all of our themes.