### PR TITLE
[QRF-287] CDN link when media gallery title contains "/"

### DIFF
--- a/src/utils/getUploadcareGroupUrl.ts
+++ b/src/utils/getUploadcareGroupUrl.ts
@@ -9,5 +9,5 @@ import { ASSETS_URL } from './constants';
  */
 export function getUploadcareGroupUrl(uuid: string, title: string) {
     // UploadCare doesn't like slashes in filenames even in encoded form.
-    return `${ASSETS_URL}/${uuid}/archive/zip/${encodeURIComponent(title.replace('/', '_'))}.zip`;
+    return `${ASSETS_URL}/${uuid}/archive/zip/${encodeURIComponent(title.replace(/\//g, '_'))}.zip`;
 }


### PR DESCRIPTION
Apparently, `replace()` only replaces the first occurrence by default.

https://stackoverflow.com/questions/1967119/why-does-javascript-replace-only-first-instance-when-using-replace