### PR TITLE
[QRF-673] Add `withHighlightedStory` parameter to properly handle highlighted stories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "3.1.1",
+  "version": "3.2.0-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prezly/theme-kit-nextjs",
-      "version": "3.1.1",
+      "version": "3.2.0-0",
       "license": "MIT",
       "dependencies": {
         "@prezly/sdk": "^11.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "3.2.0-1",
+  "version": "3.2.0-2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prezly/theme-kit-nextjs",
-      "version": "3.2.0-1",
+      "version": "3.2.0-2",
       "license": "MIT",
       "dependencies": {
         "@prezly/sdk": "^11.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "3.2.0-2",
+  "version": "3.2.0-3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prezly/theme-kit-nextjs",
-      "version": "3.2.0-2",
+      "version": "3.2.0-3",
       "license": "MIT",
       "dependencies": {
         "@prezly/sdk": "^11.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "3.2.0-3",
+  "version": "3.2.0-4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prezly/theme-kit-nextjs",
-      "version": "3.2.0-3",
+      "version": "3.2.0-4",
       "license": "MIT",
       "dependencies": {
         "@prezly/sdk": "^11.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "3.2.0-0",
+  "version": "3.2.0-1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prezly/theme-kit-nextjs",
-      "version": "3.2.0-0",
+      "version": "3.2.0-1",
       "license": "MIT",
       "dependencies": {
         "@prezly/sdk": "^11.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "3.2.0-2",
+  "version": "3.2.0-3",
   "description": "Data layer and utility library for developing Prezly themes with NextJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "3.2.0-3",
+  "version": "3.2.0-4",
   "description": "Data layer and utility library for developing Prezly themes with NextJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "3.1.1",
+  "version": "3.2.0-0",
   "description": "Data layer and utility library for developing Prezly themes with NextJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "3.2.0-0",
+  "version": "3.2.0-1",
   "description": "Data layer and utility library for developing Prezly themes with NextJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "3.2.0-1",
+  "version": "3.2.0-2",
   "description": "Data layer and utility library for developing Prezly themes with NextJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/adapter-nextjs/api-handlers/fetchStories.ts
+++ b/src/adapter-nextjs/api-handlers/fetchStories.ts
@@ -8,14 +8,14 @@ export async function fetchStories(req: NextApiRequest, res: NextApiResponse) {
         return;
     }
 
-    const { page, pageSize, category, include, localeCode } = req.body;
+    const { page, pageSize, useHighlightedStory, category, include, localeCode } = req.body;
 
     try {
         const api = getPrezlyApi(req);
 
         const { stories } = await (category
             ? api.getStoriesFromCategory(category, { page, pageSize, include, localeCode })
-            : api.getStories({ page, pageSize, include, localeCode }));
+            : api.getStories({ page, pageSize, include, localeCode, useHighlightedStory }));
 
         res.status(200).json({ stories });
     } catch (error) {

--- a/src/adapter-nextjs/api-handlers/fetchStories.ts
+++ b/src/adapter-nextjs/api-handlers/fetchStories.ts
@@ -8,14 +8,22 @@ export async function fetchStories(req: NextApiRequest, res: NextApiResponse) {
         return;
     }
 
-    const { page, pageSize, useHighlightedStory, category, include, localeCode } = req.body;
+    const { page, pageSize, useHighlightedStory, category, include, localeCode, pinning } =
+        req.body;
 
     try {
         const api = getPrezlyApi(req);
 
         const { stories } = await (category
             ? api.getStoriesFromCategory(category, { page, pageSize, include, localeCode })
-            : api.getStories({ page, pageSize, include, localeCode, useHighlightedStory }));
+            : api.getStories({
+                  page,
+                  pageSize,
+                  include,
+                  localeCode,
+                  useHighlightedStory,
+                  pinning,
+              }));
 
         res.status(200).json({ stories });
     } catch (error) {

--- a/src/adapter-nextjs/api-handlers/fetchStories.ts
+++ b/src/adapter-nextjs/api-handlers/fetchStories.ts
@@ -8,7 +8,7 @@ export async function fetchStories(req: NextApiRequest, res: NextApiResponse) {
         return;
     }
 
-    const { page, pageSize, useHighlightedStory, category, include, localeCode, pinning } =
+    const { page, pageSize, withHighlightedStory, category, include, localeCode, pinning } =
         req.body;
 
     try {
@@ -21,7 +21,7 @@ export async function fetchStories(req: NextApiRequest, res: NextApiResponse) {
                   pageSize,
                   include,
                   localeCode,
-                  useHighlightedStory,
+                  withHighlightedStory,
                   pinning,
               }));
 

--- a/src/adapter-nextjs/page-props/home.ts
+++ b/src/adapter-nextjs/page-props/home.ts
@@ -26,7 +26,7 @@ interface Options {
      * When set to `true`, the initial `stories` array will include one extra story to place as highlighted story.
      * This will offset each subsequent page by 1 story to account for that.
      */
-    useHighlightedStory?: boolean;
+    withHighlightedStory?: boolean;
     pageSize?: number;
     pinning?: boolean;
 }
@@ -39,7 +39,7 @@ export function getHomepageServerSideProps<
         pageSize = DEFAULT_PAGE_SIZE,
         extraStoryFields,
         pinning = false,
-        useHighlightedStory = false,
+        withHighlightedStory = false,
     } = options || {};
 
     return async function getServerSideProps(
@@ -60,7 +60,7 @@ export function getHomepageServerSideProps<
             pinning,
             include: extraStoryFields,
             localeCode,
-            useHighlightedStory,
+            withHighlightedStory,
         });
         const { stories, storiesTotal } = storiesPaginated;
 
@@ -74,7 +74,7 @@ export function getHomepageServerSideProps<
                     itemsTotal: storiesTotal,
                     currentPage: page ?? 1,
                     pageSize,
-                    useHighlightedStory,
+                    withHighlightedStory,
                 },
                 ...(typeof customProps === 'function'
                     ? await (customProps as PropsFunction<CustomProps>)(context, serverSideProps)

--- a/src/adapter-nextjs/page-props/home.ts
+++ b/src/adapter-nextjs/page-props/home.ts
@@ -22,6 +22,11 @@ export interface HomePageProps<StoryType extends Story = Story> {
 
 interface Options {
     extraStoryFields?: (keyof Story.ExtraFields)[];
+    /**
+     * When set to `true`, the initial `stories` array will include one extra story to place as highlighted story.
+     * This will offset each subsequent page by 1 story to account for that.
+     */
+    useHighlightedStory?: boolean;
     pageSize?: number;
     pinning?: boolean;
 }
@@ -30,7 +35,12 @@ export function getHomepageServerSideProps<
     CustomProps extends Record<string, any>,
     StoryType extends Story = Story,
 >(customProps: CustomProps | PropsFunction<CustomProps>, options?: Options) {
-    const { pageSize = DEFAULT_PAGE_SIZE, extraStoryFields, pinning = false } = options || {};
+    const {
+        pageSize = DEFAULT_PAGE_SIZE,
+        extraStoryFields,
+        pinning = false,
+        useHighlightedStory = false,
+    } = options || {};
 
     return async function getServerSideProps(
         context: GetServerSidePropsContext,
@@ -50,6 +60,7 @@ export function getHomepageServerSideProps<
             pinning,
             include: extraStoryFields,
             localeCode,
+            useHighlightedStory,
         });
         const { stories, storiesTotal } = storiesPaginated;
 
@@ -63,6 +74,7 @@ export function getHomepageServerSideProps<
                     itemsTotal: storiesTotal,
                     currentPage: page ?? 1,
                     pageSize,
+                    useHighlightedStory,
                 },
                 ...(typeof customProps === 'function'
                     ? await (customProps as PropsFunction<CustomProps>)(context, serverSideProps)

--- a/src/data-fetching/api/PrezlyApi.ts
+++ b/src/data-fetching/api/PrezlyApi.ts
@@ -159,6 +159,8 @@ export class PrezlyApi {
             return useHighlightedStory && baseOffset ? baseOffset + 1 : baseOffset;
         }
 
+        console.log({ limit, offset: getPageOffset(), useHighlightedStory });
+
         const { stories, pagination } = await this.searchStories({
             limit,
             offset: getPageOffset(),

--- a/src/data-fetching/api/PrezlyApi.ts
+++ b/src/data-fetching/api/PrezlyApi.ts
@@ -152,8 +152,6 @@ export class PrezlyApi {
         const baseOffset = typeof page !== 'undefined' ? (page - 1) * pageSize : undefined;
         const offset = useHighlightedStory && baseOffset ? baseOffset + 1 : baseOffset;
 
-        console.log({ limit, offset, useHighlightedStory });
-
         const { stories, pagination } = await this.searchStories({
             limit,
             offset,

--- a/src/data-fetching/api/PrezlyApi.ts
+++ b/src/data-fetching/api/PrezlyApi.ts
@@ -21,6 +21,7 @@ import type { PageProps, ServerSidePageProps } from '../../types';
 import { DEFAULT_PAGE_SIZE } from '../../utils';
 import { getAlgoliaSettings, isSdkError, isUuid } from '../lib';
 
+import { toPaginationParams } from './lib';
 import {
     getChronologicalSortOrder,
     getContactsQuery,
@@ -148,9 +149,7 @@ export class PrezlyApi {
         const sortOrder = getChronologicalSortOrder(order, pinning);
         const query = JSON.stringify(getStoriesQuery(this.newsroomUuid, undefined, localeCode));
 
-        const limit = withHighlightedStory && (!page || page === 1) ? pageSize + 1 : pageSize;
-        const baseOffset = typeof page !== 'undefined' ? (page - 1) * pageSize : undefined;
-        const offset = withHighlightedStory && baseOffset ? baseOffset + 1 : baseOffset;
+        const { offset, limit } = toPaginationParams({ page, pageSize, withHighlightedStory });
 
         const { stories, pagination } = await this.searchStories({
             limit,
@@ -178,9 +177,11 @@ export class PrezlyApi {
         const sortOrder = getChronologicalSortOrder(order);
         const query = JSON.stringify(getStoriesQuery(this.newsroomUuid, category.id, localeCode));
 
+        const { offset, limit } = toPaginationParams({ page, pageSize });
+
         const { stories, pagination } = await this.searchStories({
-            limit: pageSize,
-            offset: typeof page === 'undefined' ? undefined : (page - 1) * pageSize,
+            limit,
+            offset,
             sortOrder,
             query,
             include,
@@ -224,12 +225,11 @@ export class PrezlyApi {
     searchStories: Stories.Client['search'] = (options) => this.sdk.stories.search(options);
 
     async getGalleries({ page, pageSize }: GetGalleriesOptions) {
+        const { offset, limit } = toPaginationParams({ page, pageSize });
+
         return this.sdk.newsroomGalleries.search(this.newsroomUuid, {
-            limit: pageSize,
-            offset:
-                typeof page === 'undefined' || typeof pageSize === 'undefined'
-                    ? undefined
-                    : (page - 1) * pageSize,
+            limit,
+            offset,
             scope: getGalleriesQuery(),
         });
     }

--- a/src/data-fetching/api/PrezlyApi.ts
+++ b/src/data-fetching/api/PrezlyApi.ts
@@ -47,7 +47,7 @@ interface GetStoriesOptions {
      * When set to `true`, the result for the first page will include one extra story to place as highlighted story.
      * This will offset each subsequent page by 1 story to account for that.
      */
-    useHighlightedStory?: boolean;
+    withHighlightedStory?: boolean;
 }
 
 interface GetGalleriesOptions {
@@ -143,14 +143,14 @@ export class PrezlyApi {
         pinning = false,
         include,
         localeCode,
-        useHighlightedStory,
+        withHighlightedStory,
     }: GetStoriesOptions = {}) {
         const sortOrder = getChronologicalSortOrder(order, pinning);
         const query = JSON.stringify(getStoriesQuery(this.newsroomUuid, undefined, localeCode));
 
-        const limit = useHighlightedStory && (!page || page === 1) ? pageSize + 1 : pageSize;
+        const limit = withHighlightedStory && (!page || page === 1) ? pageSize + 1 : pageSize;
         const baseOffset = typeof page !== 'undefined' ? (page - 1) * pageSize : undefined;
-        const offset = useHighlightedStory && baseOffset ? baseOffset + 1 : baseOffset;
+        const offset = withHighlightedStory && baseOffset ? baseOffset + 1 : baseOffset;
 
         const { stories, pagination } = await this.searchStories({
             limit,
@@ -173,7 +173,7 @@ export class PrezlyApi {
             order = DEFAULT_SORT_ORDER,
             include,
             localeCode,
-        }: Omit<GetStoriesOptions, 'pinning' | 'useHighlightedStory'> = {},
+        }: Omit<GetStoriesOptions, 'pinning' | 'withHighlightedStory'> = {},
     ) {
         const sortOrder = getChronologicalSortOrder(order);
         const query = JSON.stringify(getStoriesQuery(this.newsroomUuid, category.id, localeCode));

--- a/src/data-fetching/api/PrezlyApi.ts
+++ b/src/data-fetching/api/PrezlyApi.ts
@@ -149,21 +149,14 @@ export class PrezlyApi {
         const query = JSON.stringify(getStoriesQuery(this.newsroomUuid, undefined, localeCode));
 
         const limit = useHighlightedStory && (!page || page === 1) ? pageSize + 1 : pageSize;
+        const baseOffset = typeof page !== 'undefined' ? (page - 1) * pageSize : undefined;
+        const offset = useHighlightedStory && baseOffset ? baseOffset + 1 : baseOffset;
 
-        function getPageOffset() {
-            if (typeof page === 'undefined') {
-                return undefined;
-            }
-
-            const baseOffset = (page - 1) * pageSize;
-            return useHighlightedStory && baseOffset ? baseOffset + 1 : baseOffset;
-        }
-
-        console.log({ limit, offset: getPageOffset(), useHighlightedStory });
+        console.log({ limit, offset, useHighlightedStory });
 
         const { stories, pagination } = await this.searchStories({
             limit,
-            offset: getPageOffset(),
+            offset,
             sortOrder,
             query,
             include,

--- a/src/data-fetching/api/lib.ts
+++ b/src/data-fetching/api/lib.ts
@@ -1,0 +1,24 @@
+export function toPaginationParams(params: {
+    page?: number;
+    pageSize?: number;
+    withHighlightedStory?: boolean;
+}) {
+    const { page = 1, pageSize, withHighlightedStory = false } = params;
+
+    if (!pageSize) {
+        return { offset: undefined, limit: undefined };
+    }
+
+    const offset = pageSize * (page - 1);
+    const limit = pageSize;
+
+    if (withHighlightedStory && page === 1) {
+        return { offset: 0, limit: limit + 1 };
+    }
+
+    if (withHighlightedStory && page > 1) {
+        return { offset: offset + 1, limit };
+    }
+
+    return { offset, limit };
+}

--- a/src/infinite-loading/types.ts
+++ b/src/infinite-loading/types.ts
@@ -2,4 +2,8 @@ export interface PaginationProps {
     itemsTotal: number;
     currentPage: number;
     pageSize: number;
+    /**
+     * When set to `true`, the calculated offset will be increased by one to account for the highlighted story
+     */
+    useHighlightedStory?: boolean;
 }

--- a/src/infinite-loading/types.ts
+++ b/src/infinite-loading/types.ts
@@ -5,5 +5,5 @@ export interface PaginationProps {
     /**
      * When set to `true`, the calculated offset will be increased by one to account for the highlighted story
      */
-    useHighlightedStory?: boolean;
+    withHighlightedStory?: boolean;
 }

--- a/src/infinite-loading/useInfiniteLoading.ts
+++ b/src/infinite-loading/useInfiniteLoading.ts
@@ -26,8 +26,9 @@ export function useInfiniteLoading<T>({
     const [data, setData] = useState<T[]>(initialData);
     const [currentPage, setCurrentPage] = useState(pagination.currentPage);
 
-    const { itemsTotal, pageSize } = pagination;
-    const pagesTotal = Math.ceil(itemsTotal / pageSize);
+    const { itemsTotal, pageSize, useHighlightedStory } = pagination;
+    const adjustedItemsTotal = useHighlightedStory ? itemsTotal : itemsTotal - 1;
+    const pagesTotal = Math.ceil(adjustedItemsTotal / pageSize);
     const canLoadMore = currentPage < pagesTotal;
 
     const [{ error, status }, { execute: loadMoreFn }] = useAsync(async () => {

--- a/src/infinite-loading/useInfiniteLoading.ts
+++ b/src/infinite-loading/useInfiniteLoading.ts
@@ -26,8 +26,8 @@ export function useInfiniteLoading<T>({
     const [data, setData] = useState<T[]>(initialData);
     const [currentPage, setCurrentPage] = useState(pagination.currentPage);
 
-    const { itemsTotal, pageSize, useHighlightedStory } = pagination;
-    const adjustedItemsTotal = useHighlightedStory ? itemsTotal : itemsTotal - 1;
+    const { itemsTotal, pageSize, withHighlightedStory } = pagination;
+    const adjustedItemsTotal = withHighlightedStory ? itemsTotal : itemsTotal - 1;
     const pagesTotal = Math.ceil(adjustedItemsTotal / pageSize);
     const canLoadMore = currentPage < pagesTotal;
 

--- a/src/infinite-loading/useInfiniteStoriesLoading.ts
+++ b/src/infinite-loading/useInfiniteStoriesLoading.ts
@@ -10,6 +10,7 @@ import { useInfiniteLoading } from './useInfiniteLoading';
 async function fetchStories<T extends Story = Story>(
     page: number,
     pageSize: number,
+    useHighlightedStory: boolean,
     category?: Category,
     locale?: LocaleObject,
     include?: (keyof Story.ExtraFields)[],
@@ -22,6 +23,7 @@ async function fetchStories<T extends Story = Story>(
         body: JSON.stringify({
             page,
             pageSize,
+            useHighlightedStory,
             category,
             include,
             ...(locale && {
@@ -50,12 +52,14 @@ export function useInfiniteStoriesLoading<T extends Story = Story>(
     include?: (keyof Story.ExtraFields)[],
 ) {
     const currentLocale = useCurrentLocale();
+    const { useHighlightedStory = false } = pagination;
 
     const { canLoadMore, data, isLoading, loadMore, resetData } = useInfiniteLoading<T>({
         fetchingFn: async (nextPage, pageSize) => {
             const { stories } = await fetchStories<T>(
                 nextPage,
                 pageSize,
+                useHighlightedStory,
                 category,
                 currentLocale,
                 include,

--- a/src/infinite-loading/useInfiniteStoriesLoading.ts
+++ b/src/infinite-loading/useInfiniteStoriesLoading.ts
@@ -10,7 +10,7 @@ import { useInfiniteLoading } from './useInfiniteLoading';
 async function fetchStories<T extends Story = Story>(
     page: number,
     pageSize: number,
-    useHighlightedStory: boolean,
+    withHighlightedStory: boolean,
     category?: Category,
     locale?: LocaleObject,
     include?: (keyof Story.ExtraFields)[],
@@ -24,7 +24,7 @@ async function fetchStories<T extends Story = Story>(
         body: JSON.stringify({
             page,
             pageSize,
-            useHighlightedStory,
+            withHighlightedStory,
             category,
             include,
             pinning,
@@ -55,14 +55,14 @@ export function useInfiniteStoriesLoading<T extends Story = Story>(
     pinning?: boolean,
 ) {
     const currentLocale = useCurrentLocale();
-    const { useHighlightedStory = false } = pagination;
+    const { withHighlightedStory = false } = pagination;
 
     const { canLoadMore, data, isLoading, loadMore, resetData } = useInfiniteLoading<T>({
         fetchingFn: async (nextPage, pageSize) => {
             const { stories } = await fetchStories<T>(
                 nextPage,
                 pageSize,
-                useHighlightedStory,
+                withHighlightedStory,
                 category,
                 currentLocale,
                 include,

--- a/src/infinite-loading/useInfiniteStoriesLoading.ts
+++ b/src/infinite-loading/useInfiniteStoriesLoading.ts
@@ -14,6 +14,7 @@ async function fetchStories<T extends Story = Story>(
     category?: Category,
     locale?: LocaleObject,
     include?: (keyof Story.ExtraFields)[],
+    pinning?: boolean,
 ): Promise<{ stories: T[] }> {
     const result = await fetch('/api/fetch-stories', {
         method: 'POST',
@@ -26,6 +27,7 @@ async function fetchStories<T extends Story = Story>(
             useHighlightedStory,
             category,
             include,
+            pinning,
             ...(locale && {
                 localeCode: locale.toUnderscoreCode(),
             }),
@@ -50,6 +52,7 @@ export function useInfiniteStoriesLoading<T extends Story = Story>(
     pagination: PaginationProps,
     category?: Category,
     include?: (keyof Story.ExtraFields)[],
+    pinning?: boolean,
 ) {
     const currentLocale = useCurrentLocale();
     const { useHighlightedStory = false } = pagination;
@@ -63,6 +66,7 @@ export function useInfiniteStoriesLoading<T extends Story = Story>(
                 category,
                 currentLocale,
                 include,
+                pinning,
             );
             return stories;
         },


### PR DESCRIPTION
The issue that this PR is intended to fix was present on most of our themes from day one, but somehow it was either overlooked or ignored.

For themes having a dedicated "highlighted story" card (either to display latest or pinned story), the card grid does not look even, since the grid for other stories is missing one item that is moved to "highlighted".

With current abstractions, it's quite hard to have separate page sizes for the initial load and subsequent loads performed by infinite loading.

This PR adds `withHighlightedStory` to `getHomepageServerSideProps ` as well as the API methods that it uses. 
It will still use the `pageSize` parameter for infinite loading, but will load one more story for the first page, and also offset all subsequent page loads by 1 to prevent duplicate cards.

Currently this PR is blocked by API bug -> [QRF-699](https://linear.app/prezly/issue/QRF-699/sdkstoriessearch-api-endpoint-treats-offset-parameter-incorrectly)
