### PR TITLE
Add code to ignore junk Sentry error events

### DIFF
--- a/src/sentry/common.ts
+++ b/src/sentry/common.ts
@@ -1,5 +1,12 @@
 import type { init } from '@sentry/nextjs';
 
+const IGNORED_EVENT_CULPRITS = [
+    // This usually means that something happened outside of application code.
+    // All instances of errors with this origin that I found usually were caused by referring to variables that couldn't ever exist in our code.
+    // Likely misbehaving browser extensions or people playing around in DevTools trying to break the app.
+    '?(<anonymous>)',
+];
+
 export function getCommonClientOptions(dsn: string, themeName: string): Parameters<typeof init>[0] {
     return {
         dsn,
@@ -18,6 +25,35 @@ export function getCommonClientOptions(dsn: string, themeName: string): Paramete
             // This error is caused by `beacon.min.js` polyfill in Cloudflare Insights. From what we see, it doesn't affect the user experience.
             'Illegal invocation',
         ],
+
+        // Ignore global code errors that are not related to the application code.
+        // See comments in `IGNORED_EVENT_CULPRITS` const for context on each entry
+        beforeSend: (event) => {
+            // `culprit` is not a documented property, but it is present in all Sentry events and is even displayed in the interface.
+            // Just in case it's not defined, we can fallback to the stack trace.
+            if ('culprit' in event) {
+                if (
+                    typeof event.culprit === 'string' &&
+                    IGNORED_EVENT_CULPRITS.includes(event.culprit)
+                ) {
+                    return null;
+                }
+            } else if (event.exception) {
+                if (
+                    event.exception.values?.some((value) =>
+                        value.stacktrace?.frames?.some(
+                            (frame) =>
+                                frame.abs_path && IGNORED_EVENT_CULPRITS.includes(frame.abs_path),
+                        ),
+                    )
+                ) {
+                    return null;
+                }
+            }
+
+            return event;
+        },
+
         // Attach theme tag to each event
         initialScope: (scope) => {
             scope.setTags({ prezly_theme: themeName });

--- a/src/sentry/common.ts
+++ b/src/sentry/common.ts
@@ -5,6 +5,7 @@ const IGNORED_EVENT_CULPRITS = [
     // All instances of errors with this origin that I found usually were caused by referring to variables that couldn't ever exist in our code.
     // Likely misbehaving browser extensions or people playing around in DevTools trying to break the app.
     '?(<anonymous>)',
+    'global code',
 ];
 
 export function getCommonClientOptions(dsn: string, themeName: string): Parameters<typeof init>[0] {


### PR DESCRIPTION
We had lots of junk Sentry errors coming from our themes, mostly caused by misbehaving extensions or people mocking about in the DevTools. This config update should address that and clean up our Sentry dashboard big time 🤞🏻 

Here's only a small subset of errors this is intended to clean up. Note that they are all caused by referring to variables from frameworks/libraries, that are not related to our themes in any way.
<img width="564" alt="image" src="https://user-images.githubusercontent.com/1641218/221178204-3edf3998-1fbc-41c6-99db-fd3ce6760831.png">
