### PR TITLE
Refactor Sentry config event ignore logic, add extra checks

### DIFF
--- a/src/sentry/client.ts
+++ b/src/sentry/client.ts
@@ -2,6 +2,9 @@ import type { init } from '@sentry/nextjs';
 
 import { getCommonClientOptions } from './common';
 
-export function getSentryClientOptions(dsn: string, themeName: string): Parameters<typeof init>[0] {
+export function getSentryClientOptions(
+    dsn: string,
+    themeName: string | null,
+): Parameters<typeof init>[0] {
     return getCommonClientOptions(dsn, themeName);
 }

--- a/src/sentry/common.ts
+++ b/src/sentry/common.ts
@@ -9,17 +9,11 @@ const IGNORED_EVENT_CULPRITS = [
     'global code',
 ];
 
-const IGNORED_ERRORS_REGEXP = [/ReferenceError: (\w+) is not defined/gi];
-
-// Ignore global code errors that are not related to the application code.
-// See comments in `IGNORED_EVENT_CULPRITS` const for context on each entry
 function shouldExceptionBeIgnored(exception: Exception) {
-    const { stacktrace, value } = exception;
+    const { stacktrace } = exception;
 
-    if (value && IGNORED_ERRORS_REGEXP.some((regexp) => regexp.test(value))) {
-        return true;
-    }
-
+    // Ignore global code errors that are not related to the application code.
+    // See comments in `IGNORED_EVENT_CULPRITS` const for context on each entry
     if (
         stacktrace &&
         stacktrace.frames?.some(

--- a/src/sentry/common.ts
+++ b/src/sentry/common.ts
@@ -41,7 +41,10 @@ function shouldExceptionBeIgnored(exception: Exception) {
     return false;
 }
 
-export function getCommonClientOptions(dsn: string, themeName: string): Parameters<typeof init>[0] {
+export function getCommonClientOptions(
+    dsn: string,
+    themeName: string | null,
+): Parameters<typeof init>[0] {
     return {
         dsn,
         // Adjust this value in production, or use tracesSampler for greater control
@@ -70,7 +73,9 @@ export function getCommonClientOptions(dsn: string, themeName: string): Paramete
 
         // Attach theme tag to each event
         initialScope: (scope) => {
-            scope.setTags({ prezly_theme: themeName });
+            if (themeName) {
+                scope.setTags({ prezly_theme: themeName });
+            }
             return scope;
         },
     };

--- a/src/sentry/common.ts
+++ b/src/sentry/common.ts
@@ -1,12 +1,40 @@
-import type { init } from '@sentry/nextjs';
+import type { Exception, init } from '@sentry/nextjs';
 
 const IGNORED_EVENT_CULPRITS = [
     // This usually means that something happened outside of application code.
     // All instances of errors with this origin that I found usually were caused by referring to variables that couldn't ever exist in our code.
     // Likely misbehaving browser extensions or people playing around in DevTools trying to break the app.
+    '<anonymous>',
     '?(<anonymous>)',
     'global code',
 ];
+
+const IGNORED_ERRORS_REGEXP = [/ReferenceError: (\w+) is not defined/gi];
+
+// Ignore global code errors that are not related to the application code.
+// See comments in `IGNORED_EVENT_CULPRITS` const for context on each entry
+function shouldExceptionBeIgnored(exception: Exception) {
+    const { stacktrace, value } = exception;
+
+    if (value && IGNORED_ERRORS_REGEXP.some((regexp) => regexp.test(value))) {
+        return true;
+    }
+
+    if (
+        stacktrace &&
+        stacktrace.frames?.some(
+            (frame) =>
+                frame.abs_path &&
+                IGNORED_EVENT_CULPRITS.some((ignoredCulprit) =>
+                    frame.abs_path?.includes(ignoredCulprit),
+                ),
+        )
+    ) {
+        return true;
+    }
+
+    return false;
+}
 
 export function getCommonClientOptions(dsn: string, themeName: string): Parameters<typeof init>[0] {
     return {
@@ -27,34 +55,9 @@ export function getCommonClientOptions(dsn: string, themeName: string): Paramete
             'Illegal invocation',
         ],
 
-        // Ignore global code errors that are not related to the application code.
-        // See comments in `IGNORED_EVENT_CULPRITS` const for context on each entry
         beforeSend: (event) => {
-            // `culprit` is not a documented property, but it is present in all Sentry events and is even displayed in the interface.
-            // Just in case it's not defined, we can fallback to the stack trace.
-            if ('culprit' in event && typeof event.culprit === 'string') {
-                const { culprit } = event;
-                if (
-                    IGNORED_EVENT_CULPRITS.some((ignoredCulprit) =>
-                        culprit.includes(ignoredCulprit),
-                    )
-                ) {
-                    return null;
-                }
-            } else if (event.exception) {
-                if (
-                    event.exception.values?.some((value) =>
-                        value.stacktrace?.frames?.some(
-                            (frame) =>
-                                frame.abs_path &&
-                                IGNORED_EVENT_CULPRITS.some((ignoredCulprit) =>
-                                    frame.abs_path?.includes(ignoredCulprit),
-                                ),
-                        ),
-                    )
-                ) {
-                    return null;
-                }
+            if (event.exception?.values?.every(shouldExceptionBeIgnored)) {
+                return null;
             }
 
             return event;

--- a/src/sentry/server.ts
+++ b/src/sentry/server.ts
@@ -2,6 +2,9 @@ import type { init } from '@sentry/nextjs';
 
 import { getCommonClientOptions } from './common';
 
-export function getSentryServerOptions(dsn: string, themeName: string): Parameters<typeof init>[0] {
+export function getSentryServerOptions(
+    dsn: string,
+    themeName: string | null,
+): Parameters<typeof init>[0] {
     return getCommonClientOptions(dsn, themeName);
 }


### PR DESCRIPTION
The previous PR did not catch all of the junk exceptions, so I refactored the code a bit to get rid of undocumented properties and make the checks more robust