### PR TITLE
[DEV-18941] Feature - Add support for custom date/time formatting to Nextjs themes

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "10.7.0",
+  "version": "10.8.0-alpha.0",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "npmClient": "pnpm"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@prezly/theme-kit-core",
-    "version": "10.7.0",
+    "version": "10.8.0-alpha.0",
     "description": "Data layer and utility library for developing Prezly themes with JavaScript",
     "main": "build/index.mjs",
     "type": "module",
@@ -39,7 +39,7 @@
         "@prezly/sdk": "21.12.0 || ^23.x"
     },
     "dependencies": {
-        "@prezly/theme-kit-intl": "^10.6.2",
+        "@prezly/theme-kit-intl": "^10.8.0-alpha.0",
         "@prezly/uploadcare": "2.4.4",
         "@technically/is-not-undefined": "^1.0.0",
         "@technically/omit-undefined": "^1.0.4",

--- a/packages/intl/package.json
+++ b/packages/intl/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@prezly/theme-kit-intl",
-    "version": "10.6.2",
+    "version": "10.8.0-alpha.0",
     "description": "Translations for Prezly themes",
     "type": "module",
     "main": "build/index.mjs",

--- a/packages/intl/src/formatting/datetime/lib.test.ts
+++ b/packages/intl/src/formatting/datetime/lib.test.ts
@@ -1,6 +1,6 @@
 import { Locale, supportedLocales } from '../../locales';
 
-import { getDateFormat, getTimeFormat } from './lib';
+import { formatDate, formatTime, getDateFormat, getTimeFormat } from './lib';
 
 describe('getDateFormat', () => {
     test.each(supportedLocales)(
@@ -22,4 +22,74 @@ describe('getTimeFormat', () => {
             );
         },
     );
+});
+
+describe('formatDate', () => {
+    const date = new Date('2024-03-15T10:00:00.000Z');
+
+    it('formats using locale defaults when no dateFormat is provided', () => {
+        const result = formatDate(date, { locale: 'en', timezone: 'Europe/London' });
+        expect(result).toMatch(/March/);
+        expect(result).toContain('2024');
+    });
+
+    it('formats using a moment-style dateFormat when provided', () => {
+        expect(
+            formatDate(date, {
+                locale: 'en',
+                timezone: 'Europe/London',
+                dateFormat: 'DD/MM/YYYY',
+            }),
+        ).toBe('15/03/2024');
+
+        expect(
+            formatDate(date, {
+                locale: 'en',
+                timezone: 'Europe/London',
+                dateFormat: 'MMM D, YYYY',
+            }),
+        ).toBe('Mar 15, 2024');
+
+        expect(
+            formatDate(date, {
+                locale: 'en',
+                timezone: 'Europe/London',
+                dateFormat: 'DD.MM.YYYY',
+            }),
+        ).toBe('15.03.2024');
+    });
+
+    it('respects the provided timezone when using a moment-style dateFormat', () => {
+        // 2024-03-15 23:30 UTC is already 2024-03-16 in Tokyo
+        const lateNight = new Date('2024-03-15T23:30:00.000Z');
+        expect(
+            formatDate(lateNight, {
+                locale: 'en',
+                timezone: 'Asia/Tokyo',
+                dateFormat: 'DD/MM/YYYY',
+            }),
+        ).toBe('16/03/2024');
+    });
+});
+
+describe('formatTime', () => {
+    const date = new Date('2024-03-15T10:00:00.000Z');
+
+    it('appends the timezone offset when a moment-style timeFormat is provided', () => {
+        const result = formatTime(date, {
+            locale: 'en',
+            timezone: 'Europe/London',
+            timeFormat: 'HH:mm',
+        });
+        expect(result).toMatch(/^10:00 GMT[+-]\d{2}:\d{2}$/);
+    });
+
+    it('supports 12-hour moment-style format', () => {
+        const result = formatTime(date, {
+            locale: 'en',
+            timezone: 'Europe/London',
+            timeFormat: 'hh:mm a',
+        });
+        expect(result).toMatch(/^10:00 (am|AM) GMT[+-]\d{2}:\d{2}$/);
+    });
 });

--- a/packages/intl/src/formatting/datetime/lib.ts
+++ b/packages/intl/src/formatting/datetime/lib.ts
@@ -1,6 +1,7 @@
 import { Locale } from '../../locales';
 import { withCache } from '../../utils';
 
+import { formatWithMomentPattern } from './momentFormat';
 import { toDate } from './shared';
 import type { Iso8601Date, Timezone, UnixTimestampInSeconds } from './types';
 
@@ -26,12 +27,36 @@ export const getTimeFormat = withCache(
         }),
 );
 
+const getTimezoneOffsetFormat = withCache(
+    (locale: Locale.Code, timeZone: string) =>
+        new Intl.DateTimeFormat(Locale.from(locale).isoCode, {
+            timeZone,
+            timeZoneName: 'longOffset',
+            hour: 'numeric',
+        }),
+);
+
+function getTimezoneOffsetString(date: Date, locale: Locale.Code, timezone: string): string {
+    const parts = getTimezoneOffsetFormat(locale, timezone).formatToParts(date);
+    return parts.find((p) => p.type === 'timeZoneName')?.value ?? '';
+}
+
 export function formatDate(
     input: Date | Iso8601Date | UnixTimestampInSeconds,
-    context: { locale: Locale.Code; timezone: Timezone },
+    context: { locale: Locale.Code; timezone: Timezone; dateFormat?: string },
     options: Intl.DateTimeFormatOptions = {},
 ) {
     const dateTime = toDate(input);
+
+    if (context.dateFormat) {
+        return formatWithMomentPattern(
+            dateTime,
+            context.dateFormat,
+            context.locale,
+            context.timezone,
+        );
+    }
+
     const format = getDateFormat(context.locale, context.timezone, options);
 
     return format.format(dateTime);
@@ -39,10 +64,22 @@ export function formatDate(
 
 export function formatTime(
     input: Date | Iso8601Date | UnixTimestampInSeconds,
-    context: { locale: Locale.Code; timezone: Timezone },
+    context: { locale: Locale.Code; timezone: Timezone; timeFormat?: string },
     options: Intl.DateTimeFormatOptions = {},
 ) {
     const dateTime = toDate(input);
+
+    if (context.timeFormat) {
+        const formatted = formatWithMomentPattern(
+            dateTime,
+            context.timeFormat,
+            context.locale,
+            context.timezone,
+        );
+        const offset = getTimezoneOffsetString(dateTime, context.locale, context.timezone);
+        return offset ? `${formatted} ${offset}` : formatted;
+    }
+
     const format = getTimeFormat(context.locale, context.timezone, options);
 
     return format.format(dateTime);

--- a/packages/intl/src/formatting/datetime/momentFormat.test.ts
+++ b/packages/intl/src/formatting/datetime/momentFormat.test.ts
@@ -32,8 +32,4 @@ describe('formatWithMomentPattern', () => {
             '16/03/2024',
         );
     });
-
-    it('preserves text wrapped in square brackets as a literal', () => {
-        expect(formatWithMomentPattern(date, '[Year:] YYYY', 'en', 'UTC')).toBe('Year: 2024');
-    });
 });

--- a/packages/intl/src/formatting/datetime/momentFormat.test.ts
+++ b/packages/intl/src/formatting/datetime/momentFormat.test.ts
@@ -1,0 +1,39 @@
+import { formatWithMomentPattern } from './momentFormat';
+
+describe('formatWithMomentPattern', () => {
+    const date = new Date('2024-03-05T07:30:45.000Z');
+
+    test.each([
+        ['D/M/YY', '5/3/24'],
+        ['M/D/YY', '3/5/24'],
+        ['YY/M/D', '24/3/5'],
+        ['DD/MM/YYYY', '05/03/2024'],
+        ['MM/DD/YYYY', '03/05/2024'],
+        ['DD.MM.YYYY', '05.03.2024'],
+    ])('formats numeric pattern "%s" as "%s"', (pattern, expected) => {
+        expect(formatWithMomentPattern(date, pattern, 'en', 'UTC')).toBe(expected);
+    });
+
+    it('formats month abbreviations using the locale', () => {
+        expect(formatWithMomentPattern(date, 'MMM D, YYYY', 'en', 'UTC')).toBe('Mar 5, 2024');
+    });
+
+    it('formats time in 24-hour mode', () => {
+        expect(formatWithMomentPattern(date, 'HH:mm', 'en', 'UTC')).toBe('07:30');
+    });
+
+    it('formats time in 12-hour mode with am/pm marker', () => {
+        expect(formatWithMomentPattern(date, 'hh:mm a', 'en', 'UTC')).toBe('07:30 am');
+    });
+
+    it('respects the provided timezone', () => {
+        const lateNight = new Date('2024-03-15T23:30:00.000Z');
+        expect(formatWithMomentPattern(lateNight, 'DD/MM/YYYY', 'en', 'Asia/Tokyo')).toBe(
+            '16/03/2024',
+        );
+    });
+
+    it('preserves text wrapped in square brackets as a literal', () => {
+        expect(formatWithMomentPattern(date, '[Year:] YYYY', 'en', 'UTC')).toBe('Year: 2024');
+    });
+});

--- a/packages/intl/src/formatting/datetime/momentFormat.ts
+++ b/packages/intl/src/formatting/datetime/momentFormat.ts
@@ -15,7 +15,7 @@
 import { Locale } from '../../locales';
 import { withCache } from '../../utils';
 
-const TOKEN_PATTERN = /\[([^\]]+)\]|YYYY|YY|MMMM|MMM|MM|M|DD|D|HH|hh|H|h|mm|m|ss|s|a|A/g;
+const TOKEN_PATTERN = /YYYY|YY|MMMM|MMM|MM|M|DD|D|HH|hh|H|h|mm|m|ss|s|a|A/g;
 
 type IntlPart = Intl.DateTimeFormatPart;
 
@@ -68,9 +68,7 @@ export function formatWithMomentPattern(
     const minute = findPart(parts, 'minute');
     const second = findPart(parts, 'second');
 
-    return pattern.replace(TOKEN_PATTERN, (match, escaped) => {
-        if (escaped) return escaped;
-
+    return pattern.replace(TOKEN_PATTERN, (match) => {
         switch (match) {
             case 'YYYY':
                 return year;

--- a/packages/intl/src/formatting/datetime/momentFormat.ts
+++ b/packages/intl/src/formatting/datetime/momentFormat.ts
@@ -1,0 +1,132 @@
+/**
+ * Format a Date using a moment.js-style format string against a specific locale and timezone.
+ *
+ * The Prezly backend stores Newsroom date and time formats in moment.js syntax
+ * (see Newsroom['date_format'] and Newsroom['time_format']). This formatter
+ * supports the subset of moment tokens that show up in those formats and uses
+ * `Intl.DateTimeFormat.formatToParts` so the output is correctly localized and
+ * timezone-aware without pulling in a heavy dependency.
+ *
+ * Supported Newsroom date formats: D/M/YY, M/D/YY, YY/M/D, MMM D, YY,
+ * MMM D, YYYY, DD/MM/YYYY, MM/DD/YYYY, DD.MM.YYYY.
+ * Supported Newsroom time formats: hh:mm a, HH:mm.
+ */
+
+import { Locale } from '../../locales';
+import { withCache } from '../../utils';
+
+const TOKEN_PATTERN = /\[([^\]]+)\]|YYYY|YY|MMMM|MMM|MM|M|DD|D|HH|hh|H|h|mm|m|ss|s|a|A/g;
+
+type IntlPart = Intl.DateTimeFormatPart;
+
+const getPartsFormatter = withCache(
+    (locale: Locale.Code, timeZone: string) =>
+        new Intl.DateTimeFormat(Locale.from(locale).isoCode, {
+            timeZone,
+            year: 'numeric',
+            month: 'long',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+            hourCycle: 'h23',
+        }),
+);
+
+const getMonthFormatter = withCache(
+    (locale: Locale.Code, timeZone: string, month: 'long' | 'short' | 'numeric' | '2-digit') =>
+        new Intl.DateTimeFormat(Locale.from(locale).isoCode, { timeZone, month }),
+);
+
+const get12HourFormatter = withCache(
+    (locale: Locale.Code, timeZone: string) =>
+        new Intl.DateTimeFormat(Locale.from(locale).isoCode, {
+            timeZone,
+            hour: 'numeric',
+            hourCycle: 'h12',
+        }),
+);
+
+function findPart(parts: IntlPart[], type: IntlPart['type']): string {
+    return parts.find((part) => part.type === type)?.value ?? '';
+}
+
+function pad(value: string, length: number): string {
+    return value.padStart(length, '0');
+}
+
+export function formatWithMomentPattern(
+    date: Date,
+    pattern: string,
+    locale: Locale.Code,
+    timeZone: string,
+): string {
+    const parts = getPartsFormatter(locale, timeZone).formatToParts(date);
+    const year = findPart(parts, 'year');
+    const dayOfMonth = findPart(parts, 'day');
+    const hour24 = findPart(parts, 'hour');
+    const minute = findPart(parts, 'minute');
+    const second = findPart(parts, 'second');
+
+    return pattern.replace(TOKEN_PATTERN, (match, escaped) => {
+        if (escaped) return escaped;
+
+        switch (match) {
+            case 'YYYY':
+                return year;
+            case 'YY':
+                return year.slice(-2);
+            case 'MMMM': {
+                const monthParts = getMonthFormatter(locale, timeZone, 'long').formatToParts(date);
+                return findPart(monthParts, 'month');
+            }
+            case 'MMM': {
+                const monthParts = getMonthFormatter(locale, timeZone, 'short').formatToParts(date);
+                return findPart(monthParts, 'month');
+            }
+            case 'MM': {
+                const monthParts = getMonthFormatter(locale, timeZone, '2-digit').formatToParts(
+                    date,
+                );
+                return pad(findPart(monthParts, 'month'), 2);
+            }
+            case 'M': {
+                const monthParts = getMonthFormatter(locale, timeZone, 'numeric').formatToParts(
+                    date,
+                );
+                return findPart(monthParts, 'month');
+            }
+            case 'DD':
+                return pad(dayOfMonth, 2);
+            case 'D':
+                return String(Number(dayOfMonth));
+            case 'HH':
+                return pad(hour24, 2);
+            case 'H':
+                return String(Number(hour24));
+            case 'hh':
+            case 'h': {
+                const hourParts = get12HourFormatter(locale, timeZone).formatToParts(date);
+                const hour = findPart(hourParts, 'hour');
+                return match === 'hh' ? pad(hour, 2) : String(Number(hour));
+            }
+            case 'mm':
+                return pad(minute, 2);
+            case 'm':
+                return String(Number(minute));
+            case 'ss':
+                return pad(second, 2);
+            case 's':
+                return String(Number(second));
+            case 'a':
+            case 'A': {
+                const hour = Number(hour24);
+                const isAm = hour < 12;
+                if (match === 'A') return isAm ? 'AM' : 'PM';
+                return isAm ? 'am' : 'pm';
+            }
+            default:
+                return match;
+        }
+    });
+}

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@prezly/theme-kit-nextjs",
-    "version": "10.7.0",
+    "version": "10.8.0-alpha.0",
     "description": "Data layer and utility library for developing Prezly themes with NextJS",
     "type": "module",
     "main": "build/index.mjs",
@@ -95,9 +95,9 @@
         }
     },
     "dependencies": {
-        "@prezly/theme-kit-core": "^10.7.0",
-        "@prezly/theme-kit-intl": "^10.6.2",
-        "@prezly/theme-kit-react": "^10.6.2",
+        "@prezly/theme-kit-core": "^10.8.0-alpha.0",
+        "@prezly/theme-kit-intl": "^10.8.0-alpha.0",
+        "@prezly/theme-kit-react": "^10.8.0-alpha.0",
         "@technically/is-not-undefined": "^1.0.0",
         "@technically/omit-undefined": "^1.0.4",
         "json-stable-stringify": "^1.2.1",

--- a/packages/nextjs/src/adapters/intl/server.tsx
+++ b/packages/nextjs/src/adapters/intl/server.tsx
@@ -23,6 +23,14 @@ export namespace IntlAdapter {
     export interface Configuration {
         resolveDictionary?: (localeCode: Locale.Code) => Awaitable<IntlDictionary>;
         timezone: AsyncResolvable<Timezone>;
+        /**
+         * Optional moment.js style date format from `Newsroom['date_format']`.
+         */
+        dateFormat?: AsyncResolvable<string | undefined>;
+        /**
+         * Optional moment.js style time format from `Newsroom['time_format']`.
+         */
+        timeFormat?: AsyncResolvable<string | undefined>;
     }
 
     export function connect({
@@ -31,6 +39,12 @@ export namespace IntlAdapter {
     }: Configuration) {
         async function useIntl(locale: Locale.Code) {
             const timezone = await AsyncResolvable.resolve(config.timezone);
+            const dateFormat = config.dateFormat
+                ? await AsyncResolvable.resolve(config.dateFormat)
+                : undefined;
+            const timeFormat = config.timeFormat
+                ? await AsyncResolvable.resolve(config.timeFormat)
+                : undefined;
 
             const messages = await resolveDictionary(locale);
 
@@ -43,6 +57,8 @@ export namespace IntlAdapter {
                     return formatMessageString(locale, descriptor, messages, values);
                 },
                 timezone,
+                dateFormat,
+                timeFormat,
             };
         }
 
@@ -58,14 +74,20 @@ export namespace IntlAdapter {
 
         async function FormattedDate(props: Omit<BaseFormattedDate.Props, 'timezone'>) {
             const timezone = await AsyncResolvable.resolve(config.timezone);
+            const dateFormat = config.dateFormat
+                ? await AsyncResolvable.resolve(config.dateFormat)
+                : undefined;
 
-            return <BaseFormattedDate timezone={timezone} {...props} />;
+            return <BaseFormattedDate timezone={timezone} dateFormat={dateFormat} {...props} />;
         }
 
         async function FormattedTime(props: Omit<BaseFormattedTime.Props, 'timezone'>) {
             const timezone = await AsyncResolvable.resolve(config.timezone);
+            const timeFormat = config.timeFormat
+                ? await AsyncResolvable.resolve(config.timeFormat)
+                : undefined;
 
-            return <BaseFormattedTime timezone={timezone} {...props} />;
+            return <BaseFormattedTime timezone={timezone} timeFormat={timeFormat} {...props} />;
         }
 
         return { useIntl, FormattedMessage, FormattedDate, FormattedTime };

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@prezly/theme-kit-react",
-    "version": "10.6.2",
+    "version": "10.8.0-alpha.0",
     "description": "Data layer and utility library for developing Prezly themes with NextJS",
     "type": "module",
     "main": "build/index.mjs",
@@ -58,7 +58,7 @@
         "react-dom": "^18.x || ^19.x"
     },
     "dependencies": {
-        "@prezly/theme-kit-intl": "^10.6.2"
+        "@prezly/theme-kit-intl": "^10.8.0-alpha.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/react/src/intl/BaseFormattedDate.tsx
+++ b/packages/react/src/intl/BaseFormattedDate.tsx
@@ -8,13 +8,14 @@ export function BaseFormattedDate({
     value,
     locale,
     timezone,
+    dateFormat,
     ...attributes
 }: BaseFormattedDate.Props) {
     const dateTime = toDate(value);
 
     return (
         <time {...attributes} dateTime={dateTime.toISOString()}>
-            {formatDate(dateTime, { locale, timezone })}
+            {formatDate(dateTime, { locale, timezone, dateFormat })}
         </time>
     );
 }
@@ -24,5 +25,10 @@ export namespace BaseFormattedDate {
         value: Date | Iso8601Date | UnixTimestampInSeconds;
         locale: Locale.Code;
         timezone: Timezone;
+        /**
+         * Optional moment.js style date format coming from `Newsroom['date_format']`.
+         * When omitted, falls back to the locale's default long date format.
+         */
+        dateFormat?: string;
     }
 }

--- a/packages/react/src/intl/BaseFormattedTime.tsx
+++ b/packages/react/src/intl/BaseFormattedTime.tsx
@@ -8,10 +8,11 @@ export function BaseFormattedTime({
     value,
     locale,
     timezone,
+    timeFormat,
     ...attributes
 }: BaseFormattedTime.Props) {
     const dateTime = toDate(value);
-    const time = formatTime(dateTime, { locale, timezone })
+    const time = formatTime(dateTime, { locale, timezone, timeFormat })
         .replace(/GMT(?=[+-]\d{2}:\d{2})/g, 'UTC')
         .replace(/(UTC)(\+\d{2}:\d{2})/g, '($1$2)');
 
@@ -27,5 +28,10 @@ export namespace BaseFormattedTime {
         value: Date | Iso8601Date | UnixTimestampInSeconds;
         locale: Locale.Code;
         timezone: Timezone;
+        /**
+         * Optional moment.js style time format coming from `Newsroom['time_format']`.
+         * When omitted, falls back to the locale's default time format.
+         */
+        timeFormat?: string;
     }
 }

--- a/packages/react/src/intl/FormattedDate.tsx
+++ b/packages/react/src/intl/FormattedDate.tsx
@@ -5,8 +5,10 @@ import { useIntl } from './IntlContext';
 import type { Optional } from './utils';
 
 export function FormattedDate(props: FormattedDate.Props) {
-    const { timezone, locale } = useIntl();
-    return <BaseFormattedDate timezone={timezone} locale={locale} {...props} />;
+    const { timezone, locale, dateFormat } = useIntl();
+    return (
+        <BaseFormattedDate timezone={timezone} locale={locale} dateFormat={dateFormat} {...props} />
+    );
 }
 
 export namespace FormattedDate {

--- a/packages/react/src/intl/FormattedTime.tsx
+++ b/packages/react/src/intl/FormattedTime.tsx
@@ -5,8 +5,10 @@ import { useIntl } from './IntlContext';
 import type { Optional } from './utils';
 
 export function FormattedTime(props: FormattedTime.Props) {
-    const { timezone, locale } = useIntl();
-    return <BaseFormattedTime timezone={timezone} locale={locale} {...props} />;
+    const { timezone, locale, timeFormat } = useIntl();
+    return (
+        <BaseFormattedTime timezone={timezone} locale={locale} timeFormat={timeFormat} {...props} />
+    );
 }
 
 export namespace FormattedTime {

--- a/packages/react/src/intl/IntlContext.tsx
+++ b/packages/react/src/intl/IntlContext.tsx
@@ -17,6 +17,16 @@ export interface IntlContext {
     locales: Locale.Code[];
     messages: IntlDictionary;
     timezone: Timezone;
+    /**
+     * Moment.js style date format from `Newsroom['date_format']`. When provided,
+     * `FormattedDate` will format dates using this pattern.
+     */
+    dateFormat?: string;
+    /**
+     * Moment.js style time format from `Newsroom['time_format']`. When provided,
+     * `FormattedTime` will format times using this pattern.
+     */
+    timeFormat?: string;
 }
 
 const context = createContext<IntlContext>({

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@prezly/theme-kit-ui",
-    "version": "10.5.1",
+    "version": "10.8.0-alpha.0",
     "description": "UI components for Prezly themes",
     "keywords": [
         "prezly",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       next:
         specifier: ^15.1.5
-        version: 15.1.5(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 15.1.5(@babel/core@7.28.4)(@playwright/test@1.55.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -154,7 +154,7 @@ importers:
         version: 1.2.1
       next:
         specifier: ^14.x || ^15.x
-        version: 15.1.5(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 15.1.5(@babel/core@7.28.4)(@playwright/test@1.55.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react:
         specifier: ^18.x || ^19.x
         version: 19.0.0
@@ -170,7 +170,7 @@ importers:
     devDependencies:
       '@sentry/nextjs':
         specifier: 7.120.4
-        version: 7.120.4(encoding@0.1.13)(next@15.1.5(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(webpack@5.97.1)
+        version: 7.120.4(encoding@0.1.13)(next@15.1.5(@babel/core@7.28.4)(@playwright/test@1.55.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
 
   packages/react:
     dependencies:
@@ -191,7 +191,7 @@ importers:
         version: 2.2.0(react@19.0.0)
       '@prezly/analytics-nextjs':
         specifier: 3.0.0
-        version: 3.0.0(encoding@0.1.13)(next@15.1.5(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 3.0.0(encoding@0.1.13)(next@15.1.5(@babel/core@7.28.4)(@playwright/test@1.55.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@prezly/content-renderer-react-js':
         specifier: 0.41.5
         version: 0.41.5(js-cookie@3.0.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -227,7 +227,7 @@ importers:
         version: 2.30.0
       next:
         specifier: ^15.1.4
-        version: 15.1.5(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 15.1.5(@babel/core@7.28.4)(@playwright/test@1.55.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react:
         specifier: ^19.x
         version: 19.0.0
@@ -273,7 +273,7 @@ importers:
         version: 7.6.20(encoding@0.1.13)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       '@storybook/react-vite':
         specifier: 7.6.20
-        version: 7.6.20(encoding@0.1.13)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@3.29.5)(typescript@5.7.3)(vite@4.5.14(@types/node@24.5.2)(terser@5.44.0))
+        version: 7.6.20(encoding@0.1.13)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@3.29.5)(typescript@5.7.3)(vite@4.5.14(@types/node@22.18.6))
       '@storybook/testing-library':
         specifier: 0.2.2
         version: 0.2.2
@@ -282,7 +282,7 @@ importers:
         version: 1.4.6
       '@vitejs/plugin-react':
         specifier: 3.1.0
-        version: 3.1.0(vite@4.5.14(@types/node@24.5.2)(terser@5.44.0))
+        version: 3.1.0(vite@4.5.14(@types/node@22.18.6))
       autoprefixer:
         specifier: 10.4.21
         version: 10.4.21(postcss@8.5.10)
@@ -306,19 +306,19 @@ importers:
         version: 3.4.17
       vite:
         specifier: 4.5.14
-        version: 4.5.14(@types/node@24.5.2)(terser@5.44.0)
+        version: 4.5.14(@types/node@22.18.6)
       vite-plugin-dts:
         specifier: 3.9.1
-        version: 3.9.1(@types/node@24.5.2)(rollup@3.29.5)(typescript@5.7.3)(vite@4.5.14(@types/node@24.5.2)(terser@5.44.0))
+        version: 3.9.1(@types/node@22.18.6)(rollup@3.29.5)(typescript@5.7.3)(vite@4.5.14(@types/node@22.18.6))
       vite-plugin-svgr:
         specifier: 4.5.0
-        version: 4.5.0(rollup@3.29.5)(typescript@5.7.3)(vite@4.5.14(@types/node@24.5.2)(terser@5.44.0))
+        version: 4.5.0(rollup@3.29.5)(typescript@5.7.3)(vite@4.5.14(@types/node@22.18.6))
       vite-plugin-turbosnap:
         specifier: 1.0.3
         version: 1.0.3
       vite-tsconfig-paths:
         specifier: 4.3.2
-        version: 4.3.2(typescript@5.7.3)(vite@4.5.14(@types/node@24.5.2)(terser@5.44.0))
+        version: 4.3.2(typescript@5.7.3)(vite@4.5.14(@types/node@22.18.6))
 
 packages:
 
@@ -1182,28 +1182,24 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.2.4':
     resolution: {integrity: sha512-M/Iz48p4NAzMXOuH+tsn5BvG/Jb07KOMTdSVwJpicmhN309BeEyRyQX+n1XDF0JVSlu28+hiTQ2L4rZPvu7nMw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.2.4':
     resolution: {integrity: sha512-m41nFDS0ksXK2gwXL6W6yZTYPMH0LughqbsxInSKetoH6morVj43szqKx79Iudkp8WRT5SxSh7qVb8KCUiewGg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.2.4':
     resolution: {integrity: sha512-orr3nnf2Dpb2ssl6aihQtvcKtLySLta4E2UcXdp7+RTa7mfJjBgIsbS0B9GC8gVu0hjOu021aU8b3/I1tn+pVQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.2.4':
     resolution: {integrity: sha512-NXnfTeKHDFUWfxAefa57DiGmu9VyKi0cDqFpdI+1hJWQjGJhJutHPX0b5m+eXvTKOaf+brU+P0JrQAZMb5yYaQ==}
@@ -1461,79 +1457,67 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -1649,9 +1633,6 @@ packages:
   '@jridgewell/gen-mapping@0.3.12':
     resolution: {integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==}
 
-  '@jridgewell/gen-mapping@0.3.13':
-    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
-
   '@jridgewell/gen-mapping@0.3.8':
     resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
     engines: {node: '>=6.0.0'}
@@ -1667,20 +1648,11 @@ packages:
     resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
     engines: {node: '>=6.0.0'}
 
-  '@jridgewell/source-map@0.3.11':
-    resolution: {integrity: sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==}
-
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
-  '@jridgewell/sourcemap-codec@1.5.5':
-    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
-
   '@jridgewell/trace-mapping@0.3.29':
     resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
-
-  '@jridgewell/trace-mapping@0.3.31':
-    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@juggle/resize-observer@3.4.0':
     resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}
@@ -1751,28 +1723,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.1.5':
     resolution: {integrity: sha512-FG5RApf4Gu+J+pHUQxXPM81oORZrKBYKUaBTylEIQ6Lz17hKVDsLbSXInfXM0giclvXbyiLXjTv42sQMATmZ0A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.1.5':
     resolution: {integrity: sha512-NX2Ar3BCquAOYpnoYNcKz14eH03XuF7SmSlPzTSSU4PJe7+gelAjxo3Y7F2m8+hLT8ZkkqElawBp7SWBdzwqQw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.1.5':
     resolution: {integrity: sha512-EQgqMiNu3mrV5eQHOIgeuh6GB5UU57tu17iFnLfBEhYfiOfyK+vleYKh2dkRVkV6ayx3eSqbIYgE7J7na4hhcA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.1.5':
     resolution: {integrity: sha512-HPULzqR/VqryQZbZME8HJE3jNFmTGcp+uRMHabFbQl63TtDPm+oCXAz3q8XyGv2AoihwNApVlur9Up7rXWRcjg==}
@@ -1893,28 +1861,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@20.3.2':
     resolution: {integrity: sha512-HXthtN7adXCNVWs2F4wIqq2f7BcKTjsEnqg2LWV5lm4hRYvMfEvPftb0tECsEhcSQQYcvIJnLfv3vtu9HZSfVA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@20.3.2':
     resolution: {integrity: sha512-HhgHqOUT05H45zuQL+XPywQbRNFttd7Rkkr7dZnpCRdp4W8GDjfyKCoCS5qVyowAyNh9Vc7VEq9qmiLMlvf6Zg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@20.3.2':
     resolution: {integrity: sha512-NrZ8L9of2GmYEM8GMJX6QRrLJlAwM+ds2rhdY1bxwpiyCNcD3IO/gzJlBs+kG4ly05F1u/X4k/FI5dXPpjUSgw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@20.3.2':
     resolution: {integrity: sha512-yLjacZND7C1XmsC0jfRLSgeLWZUw2Oz+u3nXNvj5JX6YHtYTVLFnRbTAcI+pG2Y6v0Otf2GKb3VT5d1mQb8JvA==}
@@ -1983,10 +1947,6 @@ packages:
   '@octokit/types@13.8.0':
     resolution: {integrity: sha512-x7DjTIbEpEWXK99DMd01QfWy0hd5h4EN+Q7shkdKds3otGQP+oWE/y0A76i1OvH9fygo4ddvNf7ZvF0t78P98A==}
 
-  '@opentelemetry/api@1.9.0':
-    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
-    engines: {node: '>=8.0.0'}
-
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -2029,6 +1989,23 @@ packages:
 
   '@prezly/story-content-format@0.68.0':
     resolution: {integrity: sha512-ltBRPH+722vhiSZ513c4hSZ5A0vzJWDv6Udq+8X1kWhBesnZA7acTCoOqTxnnsfB+sj6b1OM2SBvMK4SqkX1Wg==}
+
+  '@prezly/theme-kit-core@10.7.0':
+    resolution: {integrity: sha512-RZL2DbWpBwIqEj+c3SOp9Vx6Mry9Djx0+y1x5OFlToz//A/kEiq1dxosuE/fO0IFz674e7rk8+kkR4QGlpdDYA==}
+    engines: {node: '>= 16.x', npm: '>= 8.x'}
+    peerDependencies:
+      '@prezly/sdk': 21.12.0 || ^23.x
+
+  '@prezly/theme-kit-intl@10.6.2':
+    resolution: {integrity: sha512-/rkif1Tq92EtLF2IcIV1PhitwIWpH3uk9dabGhYHZUorPWFbwCKoQqpZV0xk0gXh7UO0uQuzcpQRBWaeJTQFVA==}
+    engines: {node: '>= 14.x', npm: '>= 7.x'}
+
+  '@prezly/theme-kit-react@10.6.2':
+    resolution: {integrity: sha512-lWWgGlUPHcVkUcFsgbM2S8AsCfF6rgrIgoTtC9DLxI3OzlTSJrz4QrMlRTurckhyK6AG6K6l0HP+wLJNH/YfOg==}
+    engines: {node: '>= 20.x', npm: '>= 8.x'}
+    peerDependencies:
+      react: ^18.x || ^19.x
+      react-dom: ^18.x || ^19.x
 
   '@prezly/uploadcare-image@0.3.2':
     resolution: {integrity: sha512-gLlgSwPQzlUZqSUOw2YZ6Bceh3A0Ymf5axjQJX1V8PtIHXVLKM9pSq+pmBOoVDs4JXue/unysMTG+qZwEwz9+g==}
@@ -3261,12 +3238,6 @@ packages:
   '@types/escodegen@0.0.6':
     resolution: {integrity: sha512-AjwI4MvWx3HAOaZqYsjKWyEObT9lcVV0Y0V8nXo6cXzN8ZiMxVhf6F3d/UNvXVGKrEzL/Dluc5p+y9GkzlTWig==}
 
-  '@types/eslint-scope@3.7.7':
-    resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
-
-  '@types/eslint@9.6.1':
-    resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
-
   '@types/estree@0.0.50':
     resolution: {integrity: sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==}
 
@@ -3275,9 +3246,6 @@ packages:
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
-
-  '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/express-serve-static-core@4.19.6':
     resolution: {integrity: sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==}
@@ -3327,9 +3295,6 @@ packages:
   '@types/jquery@3.5.32':
     resolution: {integrity: sha512-b9Xbf4CkMqS02YH8zACqN1xzdxc3cO735Qe5AbSUFmyOiaWAbcpqh9Wna+Uk0vgACvoQHpWDg2rGdHkYPLmCiQ==}
 
-  '@types/json-schema@7.0.15':
-    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
-
   '@types/json-stable-stringify@1.1.0':
     resolution: {integrity: sha512-ESTsHWB72QQq+pjUFIbEz9uSCZppD31YrVkbt2rnUciTYEvcwN6uZIhX5JZeBHqRlFJ41x/7MewCs7E2Qux6Cg==}
 
@@ -3365,9 +3330,6 @@ packages:
 
   '@types/node@22.18.6':
     resolution: {integrity: sha512-r8uszLPpeIWbNKtvWRt/DbVi5zbqZyj1PTmhRMqBMvDnaz1QpmSKujUtJLrqGZeoM8v72MfYggDceY4K1itzWQ==}
-
-  '@types/node@24.5.2':
-    resolution: {integrity: sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -3492,57 +3454,6 @@ packages:
   '@vue/shared@3.5.13':
     resolution: {integrity: sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==}
 
-  '@webassemblyjs/ast@1.14.1':
-    resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
-
-  '@webassemblyjs/floating-point-hex-parser@1.13.2':
-    resolution: {integrity: sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==}
-
-  '@webassemblyjs/helper-api-error@1.13.2':
-    resolution: {integrity: sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==}
-
-  '@webassemblyjs/helper-buffer@1.14.1':
-    resolution: {integrity: sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==}
-
-  '@webassemblyjs/helper-numbers@1.13.2':
-    resolution: {integrity: sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==}
-
-  '@webassemblyjs/helper-wasm-bytecode@1.13.2':
-    resolution: {integrity: sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==}
-
-  '@webassemblyjs/helper-wasm-section@1.14.1':
-    resolution: {integrity: sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==}
-
-  '@webassemblyjs/ieee754@1.13.2':
-    resolution: {integrity: sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==}
-
-  '@webassemblyjs/leb128@1.13.2':
-    resolution: {integrity: sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==}
-
-  '@webassemblyjs/utf8@1.13.2':
-    resolution: {integrity: sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==}
-
-  '@webassemblyjs/wasm-edit@1.14.1':
-    resolution: {integrity: sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==}
-
-  '@webassemblyjs/wasm-gen@1.14.1':
-    resolution: {integrity: sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==}
-
-  '@webassemblyjs/wasm-opt@1.14.1':
-    resolution: {integrity: sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==}
-
-  '@webassemblyjs/wasm-parser@1.14.1':
-    resolution: {integrity: sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==}
-
-  '@webassemblyjs/wast-printer@1.14.1':
-    resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
-
-  '@xtuc/ieee754@1.2.0':
-    resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
-
-  '@xtuc/long@4.2.2':
-    resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
-
   '@yarnpkg/esbuild-plugin-pnp@3.0.0-rc.15':
     resolution: {integrity: sha512-kYzDJO5CA9sy+on/s2aIW0411AklfCi8Ck/4QDivOqsMKpStZA2SsR+X27VTggGwpStWaLrjJcDcdDMowtG8MA==}
     engines: {node: '>=14.15.0'}
@@ -3625,29 +3536,8 @@ packages:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
 
-  ajv-formats@2.1.1:
-    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependencies:
-      ajv: ^8.0.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
-
-  ajv-keywords@3.5.2:
-    resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
-    peerDependencies:
-      ajv: ^6.9.1
-
-  ajv-keywords@5.1.0:
-    resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
-    peerDependencies:
-      ajv: ^8.8.2
-
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
-
-  ajv@8.17.1:
-    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
   algoliasearch-helper@3.23.0:
     resolution: {integrity: sha512-8CK4Gb/ju4OesAYcS+mjBpNiVA7ILWpg7D2vhBZohh0YkG8QT1KZ9LG+8+EntQBUGoKtPy06OFhiwP4f5zzAQg==}
@@ -3838,10 +3728,6 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.8.6:
-    resolution: {integrity: sha512-wrH5NNqren/QMtKUEEJf7z86YjfqW/2uw3IL3/xpqZUC95SSVIFXYQeeGjL6FT/X68IROu6RMehZQS5foy2BXw==}
-    hasBin: true
-
   before-after-hook@2.2.3:
     resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
 
@@ -3898,11 +3784,6 @@ packages:
 
   browserslist@4.25.1:
     resolution: {integrity: sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-
-  browserslist@4.26.2:
-    resolution: {integrity: sha512-ECFzp6uFOSB+dcZ5BK/IBaGWssbSYBHvuMeMt3MMFyhI0Z8SqGgEkBLARgpRH3hutIgPVsALcMwbDrJqPxQ65A==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -3979,9 +3860,6 @@ packages:
   caniuse-lite@1.0.30001726:
     resolution: {integrity: sha512-VQAUIUzBiZ/UnlM28fSp2CRF3ivUn1BWEvxMcVTNwpw91Py1pGbPIyIKtd+tzct9C3ouceCVdGAXxZOpZAsgdw==}
 
-  caniuse-lite@1.0.30001743:
-    resolution: {integrity: sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==}
-
   chalk@3.0.0:
     resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
     engines: {node: '>=8'}
@@ -4011,10 +3889,6 @@ packages:
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
-
-  chrome-trace-event@1.0.4:
-    resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
-    engines: {node: '>=6.0'}
 
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
@@ -4115,9 +3989,6 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
-
-  commander@2.20.3:
-    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -4525,9 +4396,6 @@ packages:
   electron-to-chromium@1.5.179:
     resolution: {integrity: sha512-UWKi/EbBopgfFsc5k61wFpV7WrnnSlSzW/e2XcBmS6qKYTivZlLtoll5/rdqRTxGglGHkmkW0j0pFNJG10EUIQ==}
 
-  electron-to-chromium@1.5.223:
-    resolution: {integrity: sha512-qKm55ic6nbEmagFlTFczML33rF90aU+WtrJ9MdTCThrcvDNdUHN4p6QfVN78U06ZmguqXIyMPyYhw2TrbDUwPQ==}
-
   electron-to-chromium@1.5.84:
     resolution: {integrity: sha512-I+DQ8xgafao9Ha6y0qjHHvpZ9OfyA1qKlkHkjywxzniORU2awxyz7f/iVJcULmrF2yrM3nHQf+iDjJtbbexd/g==}
 
@@ -4554,10 +4422,6 @@ packages:
 
   end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
-
-  enhanced-resolve@5.18.3:
-    resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
-    engines: {node: '>=10.13.0'}
 
   enquirer@2.3.6:
     resolution: {integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==}
@@ -4596,9 +4460,6 @@ packages:
   es-module-lexer@0.9.3:
     resolution: {integrity: sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==}
 
-  es-module-lexer@1.7.0:
-    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
-
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -4636,22 +4497,10 @@ packages:
     engines: {node: '>=6.0'}
     hasBin: true
 
-  eslint-scope@5.1.1:
-    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
-    engines: {node: '>=8.0.0'}
-
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
-
-  esrecurse@4.3.0:
-    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
-    engines: {node: '>=4.0'}
-
-  estraverse@4.3.0:
-    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
-    engines: {node: '>=4.0'}
 
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
@@ -4670,10 +4519,6 @@ packages:
 
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
-
-  events@3.3.0:
-    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
-    engines: {node: '>=0.8.x'}
 
   execa@5.0.0:
     resolution: {integrity: sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==}
@@ -4725,9 +4570,6 @@ packages:
 
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
-
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fastq@1.18.0:
     resolution: {integrity: sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==}
@@ -5582,10 +5424,6 @@ packages:
     resolution: {integrity: sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  jest-worker@27.5.1:
-    resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
-    engines: {node: '>= 10.13.0'}
-
   jest-worker@29.7.0:
     resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -5663,9 +5501,6 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
-
-  json-schema-traverse@1.0.0:
-    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-stable-stringify@1.2.1:
     resolution: {integrity: sha512-Lp6HbbBgosLmJbjx0pBLbgvx68FaFU1sdkmBuckmhhJ88kL13OA51CDtR2yJB50eCNMH9wRqtQNNiAqQH4YXnA==}
@@ -5766,10 +5601,6 @@ packages:
   load-json-file@6.2.0:
     resolution: {integrity: sha512-gUD/epcRms75Cw8RT1pUdHugZYM5ce64ucs2GEISABwkRsOQr0q2wm/MV2TKThycIe5e0ytRweW2RZxclogCdQ==}
     engines: {node: '>=8'}
-
-  loader-runner@4.3.0:
-    resolution: {integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==}
-    engines: {node: '>=6.11.5'}
 
   localforage@1.10.0:
     resolution: {integrity: sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==}
@@ -6175,9 +6006,6 @@ packages:
 
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
-
-  node-releases@2.0.21:
-    resolution: {integrity: sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==}
 
   nopt@1.0.10:
     resolution: {integrity: sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==}
@@ -6758,9 +6586,6 @@ packages:
   ramda@0.29.0:
     resolution: {integrity: sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA==}
 
-  randombytes@2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
-
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -6971,10 +6796,6 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
-  require-from-string@2.0.2:
-    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
-    engines: {node: '>=0.10.0'}
-
   resize-observer-polyfill@1.5.1:
     resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}
 
@@ -7082,14 +6903,6 @@ packages:
   scheduler@0.25.0:
     resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
 
-  schema-utils@3.3.0:
-    resolution: {integrity: sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==}
-    engines: {node: '>= 10.13.0'}
-
-  schema-utils@4.3.2:
-    resolution: {integrity: sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==}
-    engines: {node: '>= 10.13.0'}
-
   search-insights@2.17.3:
     resolution: {integrity: sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==}
 
@@ -7119,9 +6932,6 @@ packages:
   send@0.19.0:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
-
-  serialize-javascript@6.0.2:
-    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
 
   serve-static@1.16.2:
     resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
@@ -7421,10 +7231,6 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
-  tapable@2.2.3:
-    resolution: {integrity: sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg==}
-    engines: {node: '>=6'}
-
   tar-fs@2.1.2:
     resolution: {integrity: sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==}
 
@@ -7455,27 +7261,6 @@ packages:
   tempy@1.0.1:
     resolution: {integrity: sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==}
     engines: {node: '>=10'}
-
-  terser-webpack-plugin@5.3.14:
-    resolution: {integrity: sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      '@swc/core': '*'
-      esbuild: '*'
-      uglify-js: '*'
-      webpack: ^5.1.0
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      esbuild:
-        optional: true
-      uglify-js:
-        optional: true
-
-  terser@5.44.0:
-    resolution: {integrity: sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w==}
-    engines: {node: '>=10'}
-    hasBin: true
 
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
@@ -7687,9 +7472,6 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
-  undici-types@7.12.0:
-    resolution: {integrity: sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==}
 
   unfetch@3.1.2:
     resolution: {integrity: sha512-L0qrK7ZeAudGiKYw6nzFjnJ2D5WHblUBwmHIqtPS6oKUd+Hcpk7/hKsSmcHsTlpd1TbTNsiRBUKRq3bHLNIqIw==}
@@ -7945,10 +7727,6 @@ packages:
     resolution: {integrity: sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==}
     engines: {node: '>=10.13.0'}
 
-  watchpack@2.4.4:
-    resolution: {integrity: sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==}
-    engines: {node: '>=10.13.0'}
-
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
@@ -7959,22 +7737,8 @@ packages:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
     engines: {node: '>=10.13.0'}
 
-  webpack-sources@3.3.3:
-    resolution: {integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==}
-    engines: {node: '>=10.13.0'}
-
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
-
-  webpack@5.97.1:
-    resolution: {integrity: sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    peerDependencies:
-      webpack-cli: '*'
-    peerDependenciesMeta:
-      webpack-cli:
-        optional: true
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -9707,13 +9471,13 @@ snapshots:
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.3.0(typescript@5.7.3)(vite@4.5.14(@types/node@24.5.2)(terser@5.44.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.3.0(typescript@5.7.3)(vite@4.5.14(@types/node@22.18.6))':
     dependencies:
       glob: 7.2.3
       glob-promise: 4.2.2(glob@7.2.3)
       magic-string: 0.27.0
       react-docgen-typescript: 2.2.2(typescript@5.7.3)
-      vite: 4.5.14(@types/node@24.5.2)(terser@5.44.0)
+      vite: 4.5.14(@types/node@22.18.6)
     optionalDependencies:
       typescript: 5.7.3
 
@@ -9721,12 +9485,6 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
       '@jridgewell/trace-mapping': 0.3.29
-
-  '@jridgewell/gen-mapping@0.3.13':
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
-      '@jridgewell/trace-mapping': 0.3.31
-    optional: true
 
   '@jridgewell/gen-mapping@0.3.8':
     dependencies:
@@ -9743,27 +9501,12 @@ snapshots:
 
   '@jridgewell/set-array@1.2.1': {}
 
-  '@jridgewell/source-map@0.3.11':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-    optional: true
-
   '@jridgewell/sourcemap-codec@1.5.0': {}
-
-  '@jridgewell/sourcemap-codec@1.5.5':
-    optional: true
 
   '@jridgewell/trace-mapping@0.3.29':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
-
-  '@jridgewell/trace-mapping@0.3.31':
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.5
-    optional: true
 
   '@juggle/resize-observer@3.4.0': {}
 
@@ -9868,23 +9611,23 @@ snapshots:
       '@types/react': 19.1.13
       react: 19.0.0
 
-  '@microsoft/api-extractor-model@7.28.13(@types/node@24.5.2)':
+  '@microsoft/api-extractor-model@7.28.13(@types/node@22.18.6)':
     dependencies:
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 4.0.2(@types/node@24.5.2)
+      '@rushstack/node-core-library': 4.0.2(@types/node@22.18.6)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.43.0(@types/node@24.5.2)':
+  '@microsoft/api-extractor@7.43.0(@types/node@22.18.6)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.28.13(@types/node@24.5.2)
+      '@microsoft/api-extractor-model': 7.28.13(@types/node@22.18.6)
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 4.0.2(@types/node@24.5.2)
+      '@rushstack/node-core-library': 4.0.2(@types/node@22.18.6)
       '@rushstack/rig-package': 0.5.2
-      '@rushstack/terminal': 0.10.0(@types/node@24.5.2)
-      '@rushstack/ts-command-line': 4.19.1(@types/node@24.5.2)
+      '@rushstack/terminal': 0.10.0(@types/node@22.18.6)
+      '@rushstack/ts-command-line': 4.19.1(@types/node@22.18.6)
       lodash: 4.17.21
       minimatch: 3.0.5
       resolve: 1.22.10
@@ -10193,9 +9936,6 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 23.0.1
 
-  '@opentelemetry/api@1.9.0':
-    optional: true
-
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -10203,13 +9943,13 @@ snapshots:
     dependencies:
       playwright: 1.55.0
 
-  '@prezly/analytics-nextjs@3.0.0(encoding@0.1.13)(next@15.1.5(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@prezly/analytics-nextjs@3.0.0(encoding@0.1.13)(next@15.1.5(@babel/core@7.28.4)(@playwright/test@1.55.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@react-hookz/web': 14.7.1(js-cookie@3.0.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@segment/analytics-next': 1.76.1(encoding@0.1.13)
       js-cookie: 3.0.5
-      next: 15.1.5(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      next-plausible: 3.12.4(next@15.1.5(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next: 15.1.5(@babel/core@7.28.4)(@playwright/test@1.55.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next-plausible: 3.12.4(next@15.1.5(@babel/core@7.28.4)(@playwright/test@1.55.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
     transitivePeerDependencies:
@@ -10259,6 +9999,26 @@ snapshots:
       '@prezly/content-format': 0.68.0
       '@prezly/uploads': 0.2.1
       is-plain-object: 5.0.0
+
+  '@prezly/theme-kit-core@10.7.0(@prezly/sdk@23.20.0)':
+    dependencies:
+      '@prezly/sdk': 23.20.0
+      '@prezly/theme-kit-intl': 10.6.2
+      '@prezly/uploadcare': 2.4.4
+      '@technically/is-not-undefined': 1.0.0
+      '@technically/omit-undefined': 1.0.4
+      parse-data-url: 6.0.0
+      url-pattern: 1.0.3
+
+  '@prezly/theme-kit-intl@10.6.2':
+    dependencies:
+      '@technically/is-not-undefined': 1.0.0
+
+  '@prezly/theme-kit-react@10.6.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@prezly/theme-kit-intl': 10.6.2
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
   '@prezly/uploadcare-image@0.3.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
@@ -10922,7 +10682,7 @@ snapshots:
     optionalDependencies:
       rollup: 3.29.5
 
-  '@rushstack/node-core-library@4.0.2(@types/node@24.5.2)':
+  '@rushstack/node-core-library@4.0.2(@types/node@22.18.6)':
     dependencies:
       fs-extra: 7.0.1
       import-lazy: 4.0.0
@@ -10931,23 +10691,23 @@ snapshots:
       semver: 7.5.4
       z-schema: 5.0.5
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
 
   '@rushstack/rig-package@0.5.2':
     dependencies:
       resolve: 1.22.10
       strip-json-comments: 3.1.1
 
-  '@rushstack/terminal@0.10.0(@types/node@24.5.2)':
+  '@rushstack/terminal@0.10.0(@types/node@22.18.6)':
     dependencies:
-      '@rushstack/node-core-library': 4.0.2(@types/node@24.5.2)
+      '@rushstack/node-core-library': 4.0.2(@types/node@22.18.6)
       supports-color: 8.1.1
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
 
-  '@rushstack/ts-command-line@4.19.1(@types/node@24.5.2)':
+  '@rushstack/ts-command-line@4.19.1(@types/node@22.18.6)':
     dependencies:
-      '@rushstack/terminal': 0.10.0(@types/node@24.5.2)
+      '@rushstack/terminal': 0.10.0(@types/node@22.18.6)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -11051,7 +10811,7 @@ snapshots:
       '@sentry/utils': 7.120.4
       localforage: 1.10.0
 
-  '@sentry/nextjs@7.120.4(encoding@0.1.13)(next@15.1.5(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(webpack@5.97.1)':
+  '@sentry/nextjs@7.120.4(encoding@0.1.13)(next@15.1.5(@babel/core@7.28.4)(@playwright/test@1.55.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@rollup/plugin-commonjs': 24.0.0(rollup@2.79.2)
       '@sentry/core': 7.120.4
@@ -11063,13 +10823,11 @@ snapshots:
       '@sentry/vercel-edge': 7.120.4
       '@sentry/webpack-plugin': 1.21.0(encoding@0.1.13)
       chalk: 3.0.0
-      next: 15.1.5(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next: 15.1.5(@babel/core@7.28.4)(@playwright/test@1.55.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       resolve: 1.22.8
       rollup: 2.79.2
       stacktrace-parser: 0.1.10
-    optionalDependencies:
-      webpack: 5.97.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -11370,7 +11128,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@storybook/builder-vite@7.6.20(encoding@0.1.13)(typescript@5.7.3)(vite@4.5.14(@types/node@24.5.2)(terser@5.44.0))':
+  '@storybook/builder-vite@7.6.20(encoding@0.1.13)(typescript@5.7.3)(vite@4.5.14(@types/node@22.18.6))':
     dependencies:
       '@storybook/channels': 7.6.20
       '@storybook/client-logger': 7.6.20
@@ -11388,7 +11146,7 @@ snapshots:
       fs-extra: 11.3.0
       magic-string: 0.30.17
       rollup: 3.29.5
-      vite: 4.5.14(@types/node@24.5.2)(terser@5.44.0)
+      vite: 4.5.14(@types/node@22.18.6)
     optionalDependencies:
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -11727,18 +11485,18 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
-  '@storybook/react-vite@7.6.20(encoding@0.1.13)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@3.29.5)(typescript@5.7.3)(vite@4.5.14(@types/node@24.5.2)(terser@5.44.0))':
+  '@storybook/react-vite@7.6.20(encoding@0.1.13)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@3.29.5)(typescript@5.7.3)(vite@4.5.14(@types/node@22.18.6))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.3.0(typescript@5.7.3)(vite@4.5.14(@types/node@24.5.2)(terser@5.44.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.3.0(typescript@5.7.3)(vite@4.5.14(@types/node@22.18.6))
       '@rollup/pluginutils': 5.1.4(rollup@3.29.5)
-      '@storybook/builder-vite': 7.6.20(encoding@0.1.13)(typescript@5.7.3)(vite@4.5.14(@types/node@24.5.2)(terser@5.44.0))
+      '@storybook/builder-vite': 7.6.20(encoding@0.1.13)(typescript@5.7.3)(vite@4.5.14(@types/node@22.18.6))
       '@storybook/react': 7.6.20(encoding@0.1.13)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      '@vitejs/plugin-react': 3.1.0(vite@4.5.14(@types/node@24.5.2)(terser@5.44.0))
+      '@vitejs/plugin-react': 3.1.0(vite@4.5.14(@types/node@22.18.6))
       magic-string: 0.30.17
       react: 19.0.0
       react-docgen: 7.1.0
       react-dom: 19.0.0(react@19.0.0)
-      vite: 4.5.14(@types/node@24.5.2)(terser@5.44.0)
+      vite: 4.5.14(@types/node@22.18.6)
     transitivePeerDependencies:
       - '@preact/preset-vite'
       - encoding
@@ -12022,26 +11780,11 @@ snapshots:
 
   '@types/escodegen@0.0.6': {}
 
-  '@types/eslint-scope@3.7.7':
-    dependencies:
-      '@types/eslint': 9.6.1
-      '@types/estree': 1.0.8
-    optional: true
-
-  '@types/eslint@9.6.1':
-    dependencies:
-      '@types/estree': 1.0.8
-      '@types/json-schema': 7.0.15
-    optional: true
-
   '@types/estree@0.0.50': {}
 
   '@types/estree@0.0.51': {}
 
   '@types/estree@1.0.6': {}
-
-  '@types/estree@1.0.8':
-    optional: true
 
   '@types/express-serve-static-core@4.19.6':
     dependencies:
@@ -12106,9 +11849,6 @@ snapshots:
     dependencies:
       '@types/sizzle': 2.3.9
 
-  '@types/json-schema@7.0.15':
-    optional: true
-
   '@types/json-stable-stringify@1.1.0': {}
 
   '@types/lodash@4.17.14': {}
@@ -12141,11 +11881,6 @@ snapshots:
   '@types/node@22.18.6':
     dependencies:
       undici-types: 6.21.0
-
-  '@types/node@24.5.2':
-    dependencies:
-      undici-types: 7.12.0
-    optional: true
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -12217,14 +11952,14 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@vitejs/plugin-react@3.1.0(vite@4.5.14(@types/node@24.5.2)(terser@5.44.0))':
+  '@vitejs/plugin-react@3.1.0(vite@4.5.14(@types/node@22.18.6))':
     dependencies:
       '@babel/core': 7.26.7
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.7)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.7)
       magic-string: 0.27.0
       react-refresh: 0.14.2
-      vite: 4.5.14(@types/node@24.5.2)(terser@5.44.0)
+      vite: 4.5.14(@types/node@22.18.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -12309,103 +12044,6 @@ snapshots:
 
   '@vue/shared@3.5.13': {}
 
-  '@webassemblyjs/ast@1.14.1':
-    dependencies:
-      '@webassemblyjs/helper-numbers': 1.13.2
-      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
-    optional: true
-
-  '@webassemblyjs/floating-point-hex-parser@1.13.2':
-    optional: true
-
-  '@webassemblyjs/helper-api-error@1.13.2':
-    optional: true
-
-  '@webassemblyjs/helper-buffer@1.14.1':
-    optional: true
-
-  '@webassemblyjs/helper-numbers@1.13.2':
-    dependencies:
-      '@webassemblyjs/floating-point-hex-parser': 1.13.2
-      '@webassemblyjs/helper-api-error': 1.13.2
-      '@xtuc/long': 4.2.2
-    optional: true
-
-  '@webassemblyjs/helper-wasm-bytecode@1.13.2':
-    optional: true
-
-  '@webassemblyjs/helper-wasm-section@1.14.1':
-    dependencies:
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/helper-buffer': 1.14.1
-      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
-      '@webassemblyjs/wasm-gen': 1.14.1
-    optional: true
-
-  '@webassemblyjs/ieee754@1.13.2':
-    dependencies:
-      '@xtuc/ieee754': 1.2.0
-    optional: true
-
-  '@webassemblyjs/leb128@1.13.2':
-    dependencies:
-      '@xtuc/long': 4.2.2
-    optional: true
-
-  '@webassemblyjs/utf8@1.13.2':
-    optional: true
-
-  '@webassemblyjs/wasm-edit@1.14.1':
-    dependencies:
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/helper-buffer': 1.14.1
-      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
-      '@webassemblyjs/helper-wasm-section': 1.14.1
-      '@webassemblyjs/wasm-gen': 1.14.1
-      '@webassemblyjs/wasm-opt': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      '@webassemblyjs/wast-printer': 1.14.1
-    optional: true
-
-  '@webassemblyjs/wasm-gen@1.14.1':
-    dependencies:
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
-      '@webassemblyjs/ieee754': 1.13.2
-      '@webassemblyjs/leb128': 1.13.2
-      '@webassemblyjs/utf8': 1.13.2
-    optional: true
-
-  '@webassemblyjs/wasm-opt@1.14.1':
-    dependencies:
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/helper-buffer': 1.14.1
-      '@webassemblyjs/wasm-gen': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-    optional: true
-
-  '@webassemblyjs/wasm-parser@1.14.1':
-    dependencies:
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/helper-api-error': 1.13.2
-      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
-      '@webassemblyjs/ieee754': 1.13.2
-      '@webassemblyjs/leb128': 1.13.2
-      '@webassemblyjs/utf8': 1.13.2
-    optional: true
-
-  '@webassemblyjs/wast-printer@1.14.1':
-    dependencies:
-      '@webassemblyjs/ast': 1.14.1
-      '@xtuc/long': 4.2.2
-    optional: true
-
-  '@xtuc/ieee754@1.2.0':
-    optional: true
-
-  '@xtuc/long@4.2.2':
-    optional: true
-
   '@yarnpkg/esbuild-plugin-pnp@3.0.0-rc.15(esbuild@0.18.20)':
     dependencies:
       esbuild: 0.18.20
@@ -12475,36 +12113,12 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  ajv-formats@2.1.1(ajv@8.17.1):
-    optionalDependencies:
-      ajv: 8.17.1
-    optional: true
-
-  ajv-keywords@3.5.2(ajv@6.12.6):
-    dependencies:
-      ajv: 6.12.6
-    optional: true
-
-  ajv-keywords@5.1.0(ajv@8.17.1):
-    dependencies:
-      ajv: 8.17.1
-      fast-deep-equal: 3.1.3
-    optional: true
-
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
-
-  ajv@8.17.1:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
-    optional: true
 
   algoliasearch-helper@3.23.0(algoliasearch@4.24.0):
     dependencies:
@@ -12736,9 +12350,6 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.8.6:
-    optional: true
-
   before-after-hook@2.2.3: {}
 
   better-opn@3.0.2:
@@ -12818,15 +12429,6 @@ snapshots:
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.1)
 
-  browserslist@4.26.2:
-    dependencies:
-      baseline-browser-mapping: 2.8.6
-      caniuse-lite: 1.0.30001743
-      electron-to-chromium: 1.5.223
-      node-releases: 2.0.21
-      update-browserslist-db: 1.1.3(browserslist@4.26.2)
-    optional: true
-
   bs-logger@0.2.6:
     dependencies:
       fast-json-stable-stringify: 2.1.0
@@ -12904,9 +12506,6 @@ snapshots:
 
   caniuse-lite@1.0.30001726: {}
 
-  caniuse-lite@1.0.30001743:
-    optional: true
-
   chalk@3.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -12941,9 +12540,6 @@ snapshots:
   chownr@1.1.4: {}
 
   chownr@2.0.0: {}
-
-  chrome-trace-event@1.0.4:
-    optional: true
 
   ci-info@3.9.0: {}
 
@@ -13033,9 +12629,6 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
-
-  commander@2.20.3:
-    optional: true
 
   commander@4.1.1: {}
 
@@ -13451,9 +13044,6 @@ snapshots:
 
   electron-to-chromium@1.5.179: {}
 
-  electron-to-chromium@1.5.223:
-    optional: true
-
   electron-to-chromium@1.5.84: {}
 
   emittery@0.13.1: {}
@@ -13474,12 +13064,6 @@ snapshots:
   end-of-stream@1.4.4:
     dependencies:
       once: 1.4.0
-
-  enhanced-resolve@5.18.3:
-    dependencies:
-      graceful-fs: 4.2.11
-      tapable: 2.2.3
-    optional: true
 
   enquirer@2.3.6:
     dependencies:
@@ -13514,9 +13098,6 @@ snapshots:
       stop-iteration-iterator: 1.1.0
 
   es-module-lexer@0.9.3: {}
-
-  es-module-lexer@1.7.0:
-    optional: true
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -13572,21 +13153,7 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-scope@5.1.1:
-    dependencies:
-      esrecurse: 4.3.0
-      estraverse: 4.3.0
-    optional: true
-
   esprima@4.0.1: {}
-
-  esrecurse@4.3.0:
-    dependencies:
-      estraverse: 5.3.0
-    optional: true
-
-  estraverse@4.3.0:
-    optional: true
 
   estraverse@5.3.0: {}
 
@@ -13597,9 +13164,6 @@ snapshots:
   etag@1.8.1: {}
 
   eventemitter3@4.0.7: {}
-
-  events@3.3.0:
-    optional: true
 
   execa@5.0.0:
     dependencies:
@@ -13715,9 +13279,6 @@ snapshots:
       micromatch: 4.0.8
 
   fast-json-stable-stringify@2.1.0: {}
-
-  fast-uri@3.1.0:
-    optional: true
 
   fastq@1.18.0:
     dependencies:
@@ -14783,13 +14344,6 @@ snapshots:
       jest-util: 29.7.0
       string-length: 4.0.2
 
-  jest-worker@27.5.1:
-    dependencies:
-      '@types/node': 22.18.6
-      merge-stream: 2.0.0
-      supports-color: 8.1.1
-    optional: true
-
   jest-worker@29.7.0:
     dependencies:
       '@types/node': 22.18.6
@@ -14870,9 +14424,6 @@ snapshots:
   json-parse-even-better-errors@3.0.2: {}
 
   json-schema-traverse@0.4.1: {}
-
-  json-schema-traverse@1.0.0:
-    optional: true
 
   json-stable-stringify@1.2.1:
     dependencies:
@@ -15071,9 +14622,6 @@ snapshots:
       parse-json: 5.2.0
       strip-bom: 4.0.0
       type-fest: 0.6.0
-
-  loader-runner@4.3.0:
-    optional: true
 
   localforage@1.10.0:
     dependencies:
@@ -15394,13 +14942,13 @@ snapshots:
     dependencies:
       '@segment/isodate': 1.0.3
 
-  next-plausible@3.12.4(next@15.1.5(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  next-plausible@3.12.4(next@15.1.5(@babel/core@7.28.4)(@playwright/test@1.55.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
-      next: 15.1.5(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next: 15.1.5(@babel/core@7.28.4)(@playwright/test@1.55.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
-  next@15.1.5(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  next@15.1.5(@babel/core@7.28.4)(@playwright/test@1.55.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       '@next/env': 15.1.5
       '@swc/counter': 0.1.3
@@ -15420,7 +14968,6 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.1.5
       '@next/swc-win32-arm64-msvc': 15.1.5
       '@next/swc-win32-x64-msvc': 15.1.5
-      '@opentelemetry/api': 1.9.0
       '@playwright/test': 1.55.0
       sharp: 0.33.5
     transitivePeerDependencies:
@@ -15464,9 +15011,6 @@ snapshots:
   node-machine-id@1.1.12: {}
 
   node-releases@2.0.19: {}
-
-  node-releases@2.0.21:
-    optional: true
 
   nopt@1.0.10:
     dependencies:
@@ -16099,11 +15643,6 @@ snapshots:
 
   ramda@0.29.0: {}
 
-  randombytes@2.1.0:
-    dependencies:
-      safe-buffer: 5.2.1
-    optional: true
-
   range-parser@1.2.1: {}
 
   raw-body@2.5.2:
@@ -16364,9 +15903,6 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  require-from-string@2.0.2:
-    optional: true
-
   resize-observer-polyfill@1.5.1: {}
 
   resolve-cwd@3.0.0:
@@ -16462,21 +15998,6 @@ snapshots:
 
   scheduler@0.25.0: {}
 
-  schema-utils@3.3.0:
-    dependencies:
-      '@types/json-schema': 7.0.15
-      ajv: 6.12.6
-      ajv-keywords: 3.5.2(ajv@6.12.6)
-    optional: true
-
-  schema-utils@4.3.2:
-    dependencies:
-      '@types/json-schema': 7.0.15
-      ajv: 8.17.1
-      ajv-formats: 2.1.1(ajv@8.17.1)
-      ajv-keywords: 5.1.0(ajv@8.17.1)
-    optional: true
-
   search-insights@2.17.3: {}
 
   semver@5.7.2: {}
@@ -16508,11 +16029,6 @@ snapshots:
       statuses: 2.0.1
     transitivePeerDependencies:
       - supports-color
-
-  serialize-javascript@6.0.2:
-    dependencies:
-      randombytes: 2.1.0
-    optional: true
 
   serve-static@1.16.2:
     dependencies:
@@ -16869,9 +16385,6 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tapable@2.2.3:
-    optional: true
-
   tar-fs@2.1.2:
     dependencies:
       chownr: 1.1.4
@@ -16915,24 +16428,6 @@ snapshots:
       temp-dir: 2.0.0
       type-fest: 0.16.0
       unique-string: 2.0.0
-
-  terser-webpack-plugin@5.3.14(webpack@5.97.1):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.2
-      serialize-javascript: 6.0.2
-      terser: 5.44.0
-      webpack: 5.97.1
-    optional: true
-
-  terser@5.44.0:
-    dependencies:
-      '@jridgewell/source-map': 0.3.11
-      acorn: 8.15.0
-      commander: 2.20.3
-      source-map-support: 0.5.21
-    optional: true
 
   test-exclude@6.0.0:
     dependencies:
@@ -17086,9 +16581,6 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici-types@7.12.0:
-    optional: true
-
   unfetch@3.1.2: {}
 
   unfetch@4.2.0: {}
@@ -17157,13 +16649,6 @@ snapshots:
       browserslist: 4.25.1
       escalade: 3.2.0
       picocolors: 1.1.1
-
-  update-browserslist-db@1.1.3(browserslist@4.26.2):
-    dependencies:
-      browserslist: 4.26.2
-      escalade: 3.2.0
-      picocolors: 1.1.1
-    optional: true
 
   uploadcare-widget@3.21.8:
     dependencies:
@@ -17238,9 +16723,9 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-plugin-dts@3.9.1(@types/node@24.5.2)(rollup@3.29.5)(typescript@5.7.3)(vite@4.5.14(@types/node@24.5.2)(terser@5.44.0)):
+  vite-plugin-dts@3.9.1(@types/node@22.18.6)(rollup@3.29.5)(typescript@5.7.3)(vite@4.5.14(@types/node@22.18.6)):
     dependencies:
-      '@microsoft/api-extractor': 7.43.0(@types/node@24.5.2)
+      '@microsoft/api-extractor': 7.43.0(@types/node@22.18.6)
       '@rollup/pluginutils': 5.1.4(rollup@3.29.5)
       '@vue/language-core': 1.8.27(typescript@5.7.3)
       debug: 4.4.0
@@ -17249,18 +16734,18 @@ snapshots:
       typescript: 5.7.3
       vue-tsc: 1.8.27(typescript@5.7.3)
     optionalDependencies:
-      vite: 4.5.14(@types/node@24.5.2)(terser@5.44.0)
+      vite: 4.5.14(@types/node@22.18.6)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite-plugin-svgr@4.5.0(rollup@3.29.5)(typescript@5.7.3)(vite@4.5.14(@types/node@24.5.2)(terser@5.44.0)):
+  vite-plugin-svgr@4.5.0(rollup@3.29.5)(typescript@5.7.3)(vite@4.5.14(@types/node@22.18.6)):
     dependencies:
       '@rollup/pluginutils': 5.2.0(rollup@3.29.5)
       '@svgr/core': 8.1.0(typescript@5.7.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.7.3))
-      vite: 4.5.14(@types/node@24.5.2)(terser@5.44.0)
+      vite: 4.5.14(@types/node@22.18.6)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -17268,26 +16753,25 @@ snapshots:
 
   vite-plugin-turbosnap@1.0.3: {}
 
-  vite-tsconfig-paths@4.3.2(typescript@5.7.3)(vite@4.5.14(@types/node@24.5.2)(terser@5.44.0)):
+  vite-tsconfig-paths@4.3.2(typescript@5.7.3)(vite@4.5.14(@types/node@22.18.6)):
     dependencies:
       debug: 4.4.0
       globrex: 0.1.2
       tsconfck: 3.1.4(typescript@5.7.3)
     optionalDependencies:
-      vite: 4.5.14(@types/node@24.5.2)(terser@5.44.0)
+      vite: 4.5.14(@types/node@22.18.6)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@4.5.14(@types/node@24.5.2)(terser@5.44.0):
+  vite@4.5.14(@types/node@22.18.6):
     dependencies:
       esbuild: 0.18.20
       postcss: 8.5.10
       rollup: 3.29.5
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
       fsevents: 2.3.3
-      terser: 5.44.0
 
   vue-template-compiler@2.7.16:
     dependencies:
@@ -17326,12 +16810,6 @@ snapshots:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
 
-  watchpack@2.4.4:
-    dependencies:
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-    optional: true
-
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
@@ -17340,41 +16818,7 @@ snapshots:
 
   webpack-sources@3.2.3: {}
 
-  webpack-sources@3.3.3:
-    optional: true
-
   webpack-virtual-modules@0.6.2: {}
-
-  webpack@5.97.1:
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.15.0
-      browserslist: 4.26.2
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.18.3
-      es-module-lexer: 1.7.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.0
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 3.3.0
-      tapable: 2.2.3
-      terser-webpack-plugin: 5.3.14(webpack@5.97.1)
-      watchpack: 2.4.4
-      webpack-sources: 3.3.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-    optional: true
 
   whatwg-url@5.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,7 @@ importers:
         specifier: 21.12.0 || ^23.x
         version: 23.20.0
       '@prezly/theme-kit-intl':
-        specifier: ^10.6.2
+        specifier: ^10.8.0-alpha.0
         version: link:../intl
       '@prezly/uploadcare':
         specifier: 2.4.4
@@ -135,13 +135,13 @@ importers:
         specifier: 21.12.0 || ^23.x
         version: 23.20.0
       '@prezly/theme-kit-core':
-        specifier: ^10.7.0
+        specifier: ^10.8.0-alpha.0
         version: link:../core
       '@prezly/theme-kit-intl':
-        specifier: ^10.6.2
+        specifier: ^10.8.0-alpha.0
         version: link:../intl
       '@prezly/theme-kit-react':
-        specifier: ^10.6.2
+        specifier: ^10.8.0-alpha.0
         version: link:../react
       '@technically/is-not-undefined':
         specifier: ^1.0.0
@@ -175,7 +175,7 @@ importers:
   packages/react:
     dependencies:
       '@prezly/theme-kit-intl':
-        specifier: ^10.6.2
+        specifier: ^10.8.0-alpha.0
         version: link:../intl
       react:
         specifier: ^18.x || ^19.x
@@ -1989,23 +1989,6 @@ packages:
 
   '@prezly/story-content-format@0.68.0':
     resolution: {integrity: sha512-ltBRPH+722vhiSZ513c4hSZ5A0vzJWDv6Udq+8X1kWhBesnZA7acTCoOqTxnnsfB+sj6b1OM2SBvMK4SqkX1Wg==}
-
-  '@prezly/theme-kit-core@10.7.0':
-    resolution: {integrity: sha512-RZL2DbWpBwIqEj+c3SOp9Vx6Mry9Djx0+y1x5OFlToz//A/kEiq1dxosuE/fO0IFz674e7rk8+kkR4QGlpdDYA==}
-    engines: {node: '>= 16.x', npm: '>= 8.x'}
-    peerDependencies:
-      '@prezly/sdk': 21.12.0 || ^23.x
-
-  '@prezly/theme-kit-intl@10.6.2':
-    resolution: {integrity: sha512-/rkif1Tq92EtLF2IcIV1PhitwIWpH3uk9dabGhYHZUorPWFbwCKoQqpZV0xk0gXh7UO0uQuzcpQRBWaeJTQFVA==}
-    engines: {node: '>= 14.x', npm: '>= 7.x'}
-
-  '@prezly/theme-kit-react@10.6.2':
-    resolution: {integrity: sha512-lWWgGlUPHcVkUcFsgbM2S8AsCfF6rgrIgoTtC9DLxI3OzlTSJrz4QrMlRTurckhyK6AG6K6l0HP+wLJNH/YfOg==}
-    engines: {node: '>= 20.x', npm: '>= 8.x'}
-    peerDependencies:
-      react: ^18.x || ^19.x
-      react-dom: ^18.x || ^19.x
 
   '@prezly/uploadcare-image@0.3.2':
     resolution: {integrity: sha512-gLlgSwPQzlUZqSUOw2YZ6Bceh3A0Ymf5axjQJX1V8PtIHXVLKM9pSq+pmBOoVDs4JXue/unysMTG+qZwEwz9+g==}
@@ -9999,26 +9982,6 @@ snapshots:
       '@prezly/content-format': 0.68.0
       '@prezly/uploads': 0.2.1
       is-plain-object: 5.0.0
-
-  '@prezly/theme-kit-core@10.7.0(@prezly/sdk@23.20.0)':
-    dependencies:
-      '@prezly/sdk': 23.20.0
-      '@prezly/theme-kit-intl': 10.6.2
-      '@prezly/uploadcare': 2.4.4
-      '@technically/is-not-undefined': 1.0.0
-      '@technically/omit-undefined': 1.0.4
-      parse-data-url: 6.0.0
-      url-pattern: 1.0.3
-
-  '@prezly/theme-kit-intl@10.6.2':
-    dependencies:
-      '@technically/is-not-undefined': 1.0.0
-
-  '@prezly/theme-kit-react@10.6.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
-    dependencies:
-      '@prezly/theme-kit-intl': 10.6.2
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
 
   '@prezly/uploadcare-image@0.3.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:


### PR DESCRIPTION
- Adds optional `dateFormat`/`timeFormat` parameters to `formatDate` and `formatTime` in `@prezly/theme-kit-intl`, accepting moment.js-style format strings as stored on `Newsroom['date_format']` and `Newsroom['time_format']`
- Falls back to existing `Intl.DateTimeFormat` behavior when no format is provided, so the change is backward compatible
- Introduces a small `formatWithMomentPattern` helper built on `Intl.DateTimeFormat.formatToParts` that supports the moment tokens used by Newsroom formats (e.g. `DD/MM/YYYY`, `MMM D, YYYY`, `hh:mm a`, `HH:mm`) with proper locale and timezone handling, no new dependencies
- Preserves the `(UTC+xx:xx)` suffix on `formatTime` output even when a moment-style time format is supplied
- Threads the new optional `dateFormat`/`timeFormat` props through `BaseFormattedDate`, `BaseFormattedTime`, `FormattedDate`, and `FormattedTime`
- Extends `IntlContext`/`IntlProvider` so themes can wire `newsroom.date_format` and `newsroom.time_format` once and have them apply across `<FormattedDate />` / `<FormattedTime />`
- Extends the nextjs `IntlAdapter` configuration with optional `dateFormat` and `timeFormat` (`AsyncResolvable<string | undefined>`), forwarded into the server-rendered components
- Patches `pnpm-lock.yaml` so workspace packages resolve via `link:../*` instead of the published `@prezly/theme-kit-intl@10.6.2`, which is required for CI's frozen-lockfile install to pick up the new types
- Pre-release version: **v10.8.0-alpha.0**