### PR TITLE
Add lastModified support to Sitemap.generate()

### DIFF
--- a/packages/core/src/sitemap/generate.ts
+++ b/packages/core/src/sitemap/generate.ts
@@ -9,6 +9,7 @@ import type {
     AppUrlGenerator,
     ChangeFrequency,
     ChangeFrequencyFn,
+    LastModifiedFn,
     Priority,
     PriorityFn,
     SitemapFile,
@@ -21,6 +22,7 @@ export interface Options {
     baseUrl: string;
     changeFrequency?: ChangeFrequencyFn;
     priority?: PriorityFn;
+    lastModified?: LastModifiedFn;
 }
 
 type Context = {
@@ -71,7 +73,8 @@ async function generateHomepageEntries(
     {
         priority = guessPriority,
         changeFrequency = guessChangeFrequency,
-    }: Pick<Options, 'priority' | 'changeFrequency'>,
+        lastModified = guessLastModified,
+    }: Pick<Options, 'priority' | 'changeFrequency' | 'lastModified'>,
 ) {
     const { locales, generateUrl } = context;
 
@@ -81,6 +84,7 @@ async function generateHomepageEntries(
             url: generateUrl('index', { localeCode }),
             priority: priority('index', { localeCode }),
             changeFrequency: changeFrequency('index', { localeCode }),
+            lastModified: lastModified('index', { localeCode }),
         }))
         .filter(isNonEmptyUrl);
 
@@ -92,7 +96,8 @@ async function generateStoriesEntries(
     {
         priority = guessPriority,
         changeFrequency = guessChangeFrequency,
-    }: Pick<Options, 'priority' | 'changeFrequency'>,
+        lastModified = guessLastModified,
+    }: Pick<Options, 'priority' | 'changeFrequency' | 'lastModified'>,
 ) {
     const { locales, stories, generateUrl } = context;
 
@@ -105,6 +110,7 @@ async function generateStoriesEntries(
                 url: generateUrl('story', params),
                 priority: priority('story', params),
                 changeFrequency: changeFrequency('story', params),
+                lastModified: lastModified('story', params),
             };
         })
         .filter(isNonEmptyUrl);
@@ -117,7 +123,8 @@ async function generateCategoriesEntries(
     {
         priority = guessPriority,
         changeFrequency = guessChangeFrequency,
-    }: Pick<Options, 'priority' | 'changeFrequency'>,
+        lastModified = guessLastModified,
+    }: Pick<Options, 'priority' | 'changeFrequency' | 'lastModified'>,
 ) {
     const { locales, categories, generateUrl } = context;
 
@@ -133,6 +140,7 @@ async function generateCategoriesEntries(
                         url: generateUrl('category', params),
                         priority: priority('category', params),
                         changeFrequency: changeFrequency('category', params),
+                        lastModified: lastModified('category', params),
                     };
                 }),
         )
@@ -146,7 +154,8 @@ async function generateMediaEntries(
     {
         priority = guessPriority,
         changeFrequency = guessChangeFrequency,
-    }: Pick<Options, 'priority' | 'changeFrequency'>,
+        lastModified = guessLastModified,
+    }: Pick<Options, 'priority' | 'changeFrequency' | 'lastModified'>,
 ) {
     const { newsroom, locales, generateUrl } = context;
 
@@ -158,6 +167,7 @@ async function generateMediaEntries(
             url: generateUrl('media', { localeCode }),
             priority: priority('media', { localeCode }),
             changeFrequency: changeFrequency('media', { localeCode }),
+            lastModified: lastModified('media', { localeCode }),
         }))
         .filter(isNonEmptyUrl);
 
@@ -175,6 +185,14 @@ export function guessPriority(routeName: 'index' | 'category' | 'story' | 'media
     if (routeName === 'index') return 0.9;
     if (routeName === 'category') return 0.8;
     return 0.7;
+}
+
+export function guessLastModified(
+    routeName: 'index' | 'category' | 'story' | 'media',
+    params: { localeCode: Locale.Code; updated_at?: string },
+): string | Date | undefined {
+    if (routeName === 'story') return params.updated_at;
+    return undefined;
 }
 
 export function withAlternateLinks(entries: SitemapFileEntryWithLocale[]): SitemapFileEntry[] {

--- a/packages/core/src/sitemap/index.ts
+++ b/packages/core/src/sitemap/index.ts
@@ -6,6 +6,7 @@ export {
     type Options,
     generate,
     guessChangeFrequency,
+    guessLastModified,
     guessPriority,
 } from './generate';
 export { stringify } from './stringify';

--- a/packages/core/src/sitemap/types.ts
+++ b/packages/core/src/sitemap/types.ts
@@ -68,3 +68,14 @@ export type PriorityFn = {
     ): Priority | undefined;
     (routeName: 'media', params: { localeCode: Locale.Code }): Priority | undefined;
 };
+
+// prettier-ignore
+export type LastModifiedFn = {
+    (routeName: 'index', params: { localeCode: Locale.Code }): string | Date | undefined;
+    (routeName: 'story', params: { localeCode: Locale.Code } & StoryRef): string | Date | undefined;
+    (
+        routeName: 'category',
+        params: { localeCode: Locale.Code } & TranslatedCategory,
+    ): string | Date | undefined;
+    (routeName: 'media', params: { localeCode: Locale.Code }): string | Date | undefined;
+};


### PR DESCRIPTION
## Problem

Sitemap entries generated by `Sitemap.generate()` never include `<lastmod>`,
even though the renderer (`stringify.ts`) already supports it and the
`SitemapFileEntry` type already declares the field. `Story.updated_at` (and
the equivalent field on other entities) was simply never wired through to
any entry.

This matters for SEO/AI-indexer crawl prioritization: `<lastmod>` is a
standard signal crawlers use to decide re-crawl frequency and prioritize
recently-changed content. Without it, every URL in the sitemap looks equally
"fresh" regardless of actual publish/update recency.

None of the themes consuming this package (bea and its ~19 forks) can work
around this today — `Sitemap.generate()`'s `Options` only exposes `priority`
and `changeFrequency` callbacks, with no equivalent hook for a timestamp, and
the four internal entry-builder functions aren't individually exported to
patch around.

## Fix

Adds a `lastModified` option (`LastModifiedFn`), mirroring the existing
`priority`/`changeFrequency` callback pattern exactly — same per-route-type
overload shape, same default-function convention (`guessLastModified`
alongside `guessPriority`/`guessChangeFrequency`).

`guessLastModified` populates `<lastmod>` from `story.updated_at` for story
entries. Index/category/media entries have no natural timestamp source on
their respective SDK types, so they stay unset unless a caller supplies a
custom `lastModified` function.

## Compatibility

Fully backward compatible. `lastModified` is optional and defaults to
`guessLastModified`, so any theme calling `Sitemap.generate()` without
passing the new option — which is every current caller — gets `<lastmod>`
on story entries for free after bumping the dependency. No consumer code
changes required.

## Testing

- `pnpm typecheck` — clean
- `pnpm lint` (biome) — clean
- `pnpm test:unit` — 40/40 passing, no regressions
- `pnpm build` (types + esm + cjs) — compiles clean

No existing test file covers the sitemap module, so none was added, to keep
the diff scoped to the fix.