### PR TITLE
Make intl datetime offset assertions ICU-version-robust

### DIFF
--- a/packages/intl/src/formatting/datetime/lib.test.ts
+++ b/packages/intl/src/formatting/datetime/lib.test.ts
@@ -75,13 +75,16 @@ describe('formatDate', () => {
 describe('formatTime', () => {
     const date = new Date('2024-03-15T10:00:00.000Z');
 
+    // On 2024-03-15 Europe/London is at a zero UTC offset (pre-DST). The numeric offset is
+    // optional in these patterns because `timeZoneName: 'longOffset'` renders a zero offset as
+    // bare "GMT" on ICU >= 72 (Node >= 20) but as "GMT+00:00" on older ICU — both are valid.
     it('appends the timezone offset when a moment-style timeFormat is provided', () => {
         const result = formatTime(date, {
             locale: 'en',
             timezone: 'Europe/London',
             timeFormat: 'HH:mm',
         });
-        expect(result).toMatch(/^10:00 GMT[+-]\d{2}:\d{2}$/);
+        expect(result).toMatch(/^10:00 GMT(?:[+-]\d{2}:\d{2})?$/);
     });
 
     it('supports 12-hour moment-style format', () => {
@@ -90,6 +93,6 @@ describe('formatTime', () => {
             timezone: 'Europe/London',
             timeFormat: 'hh:mm a',
         });
-        expect(result).toMatch(/^10:00 (am|AM) GMT[+-]\d{2}:\d{2}$/);
+        expect(result).toMatch(/^10:00 (am|AM) GMT(?:[+-]\d{2}:\d{2})?$/);
     });
 });


### PR DESCRIPTION
## Problem

`pnpm test` (part of the required `release:prepare` gate) fails on Node >= 20 / ICU >= 72 with two failures in `packages/intl`:

```
● formatTime › appends the timezone offset when a moment-style timeFormat is provided
    Expected pattern: /^10:00 GMT[+-]\d{2}:\d{2}$/
    Received string:  "10:00 GMT"
● formatTime › supports 12-hour moment-style format
    Expected pattern: /^10:00 (am|AM) GMT[+-]\d{2}:\d{2}$/
    Received string:  "10:00 am GMT"
```

## Root cause

The tests format `2024-03-15T10:00Z` in `Europe/London`, which is at a **zero UTC offset** on that date (pre-DST). `formatTime` appends the zone via `timeZoneName: 'longOffset'`. ICU changed how a zero offset renders under `longOffset`:

- **ICU >= 72** (Node >= 20): bare `"GMT"`
- **older ICU**: `"GMT+00:00"`

Both are valid. A non-zero offset (e.g. `GMT-04:00`) renders identically on all versions — only the zero-offset case differs. The assertions hard-required the numeric suffix, so they pass on the ICU the tests were written against but fail on newer Node/ICU. Reproduced locally on Node v22.22.0 / ICU 77.1.

This is a **test-only brittleness** — the production formatting is correct on both ICU versions. It is unrelated to any package's runtime code and blocks publishing unrelated releases (surfaced while cutting v10.9.0, whose only change was in `theme-kit-core`).

## Fix

Make the numeric offset optional in both patterns (`GMT(?:[+-]\d{2}:\d{2})?`) so they pass across ICU versions, with a comment explaining why.

## Testing

- `pnpm test` — intl 216/216 (was 214/216); all packages green
- `pnpm release:prepare` (lint + test + build) — exits 0
- No production code changed